### PR TITLE
Fix Linux samples app bugs: qwen_vl model auto-download, Stable Diffusion WebUI SoC init, and stale tokenizer URL

### DIFF
--- a/samples/apps/webui/stable-diffusion/StableDiffusionApp.py
+++ b/samples/apps/webui/stable-diffusion/StableDiffusionApp.py
@@ -9,6 +9,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "models", "generative_ai", "image_generation"))
 import stable_diffusion_v2_1.python.stable_diffusion_v2_1 as stable_diffusion_v2_1 # We need add this line before import 'gradio'.
 import gradio as gr
+import argparse
 
 
 ####################################################################
@@ -51,6 +52,7 @@ footer{display:none !important}
 ####################################################################
 
 execution_ws = os.path.dirname(os.path.abspath(__file__))
+output_dir = os.path.join(execution_ws, "images")
 
 user_prompt = ""
 uncond_prompt = ""
@@ -84,7 +86,7 @@ def infer(text, text2, step, guidance, seed, number):
 
     for i in range(number):
         stable_diffusion_v2_1.setup_parameters(user_prompt, uncond_prompt, user_seed, user_step, user_text_guidance)
-        image_path = stable_diffusion_v2_1.model_execute(modelExecuteCallback, execution_ws + "\\images", False)
+        image_path = stable_diffusion_v2_1.model_execute(modelExecuteCallback, output_dir, False)
         image_paths.append(image_path)
 
     return image_paths
@@ -92,6 +94,14 @@ def infer(text, text2, step, guidance, seed, number):
 ####################################################################
 
 if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Stable Diffusion App')
+    parser.add_argument('--soc_id', type=str, default="wos", help='Chipset ID for the device')
+    args = parser.parse_args()
+
+    print(f"StableDiffusionApp: args.soc_id = {args.soc_id}")
+    stable_diffusion_v2_1.Soc_ID_config(soc_id=args.soc_id)
+    stable_diffusion_v2_1.model_initialize()
 
     with gr.Blocks(fill_width=True, fill_height=True, css=css, theme=gr.themes.Glass()) as demo:
         demo.title = "文生图应用"
@@ -116,7 +126,7 @@ if __name__ == '__main__':
 
         btn_gr.click(infer, inputs=[text_gr, text2_gr, step_gr, guidance_gr, seed_gr, number_gr], outputs=gallery_gr)
 
-    stable_diffusion_v2_1.model_initialize()
+    # stable_diffusion_v2_1.model_initialize()
 
     # Bypass system proxy for localhost so Gradio 5.x internal startup health check succeeds.
     # Gradio calls httpx.get("http://localhost:<port>/gradio_api/startup-events") after starting

--- a/samples/models/generative_ai/image_generation/stable_diffusion_v2_1/python/stable_diffusion_v2_1.py
+++ b/samples/models/generative_ai/image_generation/stable_diffusion_v2_1/python/stable_diffusion_v2_1.py
@@ -102,6 +102,10 @@ class VaeDecoder(VaeDecoderBase):
 
 ####################################################################
 
+def Soc_ID_config(soc_id):
+    global SOC_ID
+    SOC_ID = soc_id
+
 def model_initialize():
     global model_inited
     global scheduler, tokenizer, text_encoder, unet, vae_decoder, share_memory

--- a/samples/models/multimodal/vision_language_model/qwen_vl/README.md
+++ b/samples/models/multimodal/vision_language_model/qwen_vl/README.md
@@ -36,14 +36,21 @@ python models/multimodal/vision_language_model/qwen_vl/python/qwen_vl.py
 ```
 
 With a specific model:
+Qwen2：
 ```bash
-python models/multimodal/vision_language_model/qwen_vl/python/qwen_vl.py --path /path/to/model/dir
+python models/multimodal/vision_language_model/qwen_vl/python/qwen_vl.py --model qwen2 --path models/multimodal/vision_language_model/qwen_vl/models/qwen2
+```
+
+Qwen3：
+```bash
+python models/multimodal/vision_language_model/qwen_vl/python/qwen_vl.py --model qwen3 --path models/multimodal/vision_language_model/qwen_vl/models/qwen3
 ```
 
 ## Scripts
 
 | Script | Description |
 | ------ | ----------- |
+| `python/install_model.py` | Downloads and extracts models |
 | `python/qwen_vl.py` | Main entry point with Gradio web UI |
 | `python/qwen2_vlm_qnn.py` | Qwen2-VL QNN inference implementation |
 | `python/qwen3_vlm_qnn.py` | Qwen3-VL QNN inference implementation |

--- a/samples/models/multimodal/vision_language_model/qwen_vl/python/install_model.py
+++ b/samples/models/multimodal/vision_language_model/qwen_vl/python/install_model.py
@@ -1,0 +1,148 @@
+# ... existing imports ...
+import os
+import sys
+import zipfile
+import subprocess
+import tarfile
+
+# Model configuration
+models = {
+    "qwen2": {
+        "model_zip_url": "https://www.aidevhome.com/data/adh2/models/suggested/qwen2vl2b.zip"
+    },
+    "qwen3": {
+        "model_tar_url": "https://www.aidevhome.com/data/adh2/models/suggested/qwen3-vl-4b_iq9075.tar.gz"
+    }
+}
+
+def download_with_wget(url, dest_path, proxy=None):
+    try:
+        cmd = ["wget", "-O", dest_path, url]
+        if proxy:
+            cmd.extend(["-e", f"use_proxy=yes", "-e", f"http_proxy={proxy}", "-e", f"https_proxy={proxy}"])
+        subprocess.run(cmd, check=True)
+        return True
+    except Exception as e:
+        print(f"[wget] Download failed: {e}")
+        return False
+
+def check_model_files(dir: str) -> bool:
+    """
+    Check if all required model files exist in the directory
+    
+    Args:
+        dir: Directory path to check
+    
+    Returns:
+        True if all required files exist, False otherwise
+    """
+    required_files = [
+        "veg.serialized.bin",
+        "config.json",
+        "embedding_weights_151936x1536.raw",
+        "tokenizer.json"
+    ]
+    for file in required_files:
+        file_path = os.path.join(dir, file)
+        if not os.path.exists(file_path):
+            print(f"Missing required file: {file}")
+            return False
+    return True
+
+def download_qwen_models(model_type="qwen2", base_dir=None):
+    """
+    Download Qwen models (qwen2 or qwen3)
+    
+    Args:
+        model_type: "qwen2" or "qwen3"
+        base_dir: Base directory to store models. If None, uses default path.
+    
+    Returns:
+        Model directory path if successful, None otherwise
+    """
+    if model_type not in models:
+        print(f"Unknown model type: {model_type}")
+        return None
+    
+    if base_dir is None:
+        base_dir = os.path.join("models", "multimodal","vision_language_model","qwen_vl","models")
+    
+    os.makedirs(base_dir, exist_ok=True)
+    proxy = None
+
+    model_name = model_type
+    print(f"\n=== Processing model: {model_name} ===")
+    model_dir = os.path.join(base_dir, model_name)
+    os.makedirs(model_dir, exist_ok=True)
+
+    model_config = models[model_name]
+    
+    try:
+        if model_type == "qwen2":
+            # Download zip file
+            zip_path = os.path.join(model_dir, "model.zip")
+            print("Downloading model zip...")
+            if not download_with_wget(model_config["model_zip_url"], zip_path, proxy):
+                print("Model zip download failed.")
+                return None
+
+            print("Extracting model bin files...")
+            with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+                # Extract all files to a temporary location first
+                zip_ref.extractall(model_dir)
+                
+                # Find the root folder in the zip and move its contents
+                extracted_items = os.listdir(model_dir)
+                for item in extracted_items:
+                    item_path = os.path.join(model_dir, item)
+                    # If it's a directory (the original folder like qwen2vl2b)
+                    if os.path.isdir(item_path) and item != model_name:
+                        # Move all files from the subfolder to model_dir
+                        for file in os.listdir(item_path):
+                            src = os.path.join(item_path, file)
+                            dst = os.path.join(model_dir, file)
+                            if os.path.isfile(src):
+                                os.rename(src, dst)
+                        # Remove the now-empty subfolder
+                        os.rmdir(item_path)
+            # Clean up zip file
+            os.remove(zip_path)
+            
+        elif model_type == "qwen3":
+            # Download tar.gz file
+            tar_path = os.path.join(model_dir, "model.tar.gz")
+            print("Downloading model tar.gz...")
+            if not download_with_wget(model_config["model_tar_url"], tar_path, proxy):
+                print("Model tar.gz download failed.")
+                return None
+
+            print("Extracting model files...")
+            with tarfile.open(tar_path, 'r:gz') as tar_ref:
+                tar_ref.extractall(model_dir)
+            
+            # Find the root folder in the tar and move its contents
+            extracted_items = os.listdir(model_dir)
+            for item in extracted_items:
+                item_path = os.path.join(model_dir, item)
+                # If it's a directory (the original folder)
+                if os.path.isdir(item_path) and item != model_name:
+                    # Move all files from the subfolder to model_dir
+                    for file in os.listdir(item_path):
+                        src = os.path.join(item_path, file)
+                        dst = os.path.join(model_dir, file)
+                        if os.path.isfile(src):
+                            os.rename(src, dst)
+                    # Remove the now-empty subfolder
+                    os.rmdir(item_path)
+
+            # Clean up tar file
+            os.remove(tar_path)
+
+        print(f"Model download and extraction completed for {model_type}")
+        return model_dir
+        
+    except Exception as e:
+        print(f"Failed to process model: {e}")
+        import traceback
+        traceback.print_exc()
+        return None

--- a/samples/models/multimodal/vision_language_model/qwen_vl/python/qwen_vl.py
+++ b/samples/models/multimodal/vision_language_model/qwen_vl/python/qwen_vl.py
@@ -5,6 +5,12 @@
 
 import sys
 import platform
+import subprocess
+import os
+
+# Add install_model to path for importing
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from install_model import download_qwen_models, check_model_files
 
 # ── WoS (Windows on Snapdragon) guard ─────────────────────────────────────
 # This script is designed for Linux (aarch64-oe-linux) runtime.
@@ -196,17 +202,34 @@ with gr.Blocks(title="Qwen VL Demo") as demo:
 def cleanup():
     pass
 
-def check_model_files(dir:str) -> bool:
-    required_files = [
-        "veg.serialized.bin",
-        "config.json",
-        "embedding_weights_151936x1536.raw",
-        "tokenizer.json"
-    ]
-    for file in required_files:
-        if not os.path.exists(os.path.join(dir, file)):
-            return False
-    return True
+# def check_model_files(dir:str) -> bool:
+#     required_files = [
+#         "veg.serialized.bin",
+#         "config.json",
+#         "embedding_weights_151936x1536.raw",
+#         "tokenizer.json"
+#     ]
+#     for file in required_files:
+#         if not os.path.exists(os.path.join(dir, file)):
+#             return False
+#     return True
+
+def model_download(model_type, model_dir):
+    """Download model if not already present"""
+    ret = True
+    
+    desc = f"Downloading {model_type.upper()} model... "
+    fail = f"\nFailed to download {model_type.upper()} model."
+    
+    print(desc)
+    ret = download_qwen_models(model_type=model_type)
+    
+    if model_dir is None or not check_model_files(model_dir):
+        print(fail)
+        return False, None
+    
+    print(f"Model download successful: {model_dir}")
+    return ret
 
 def load_qwen2_vlm(qwen2_vl_model_dir:str):
     veg_model_path = os.path.join(qwen2_vl_model_dir, "veg.serialized.bin")
@@ -285,13 +308,13 @@ if __name__ == "__main__":
         epilog="""
 Examples:
   # Use Qwen2-VL model (default)
-  python demo_app.py /path/to/qwen2_vl_model
+  python qwen_vl.py /path/to/qwen2_vl_model
   
   # Use Qwen3-VL model
-  python demo_app.py --model qwen3 --path /path/to/qwen3_vl_model
+  python qwen_vl.py --model qwen3 --path /path/to/qwen3_vl_model
   
   # Specify server port
-  python demo_app.py --model qwen2 --path /path/to/qwen2_vl_model --port 8080
+  python qwen_vl.py --model qwen2 --path /path/to/qwen2_vl_model --port 8080
         """
     )
     
@@ -336,15 +359,34 @@ Examples:
     # Determine model path: prioritize --path, then use positional argument
     model_dir = args.model_path if args.model_path else args.path
     
+    # if not model_dir:
+    #     parser.print_help()
+    #     print("\nError: Model path is required")
+    #     sys.exit(1)
+    
+    # if not os.path.exists(model_dir):
+    #     print(f"Error: Model directory does not exist: {model_dir}")
+    #     sys.exit(1)
+
+    # Determine model path: prioritize --path, then use positional argument
+    model_dir = args.model_path if args.model_path else args.path
+    
+    # If no path provided, attempt to download the model
     if not model_dir:
-        parser.print_help()
-        print("\nError: Model path is required")
-        sys.exit(1)
+        print(f"No model path provided. Attempting to download {args.model.upper()} model...")
+        ret = model_download(args.model, model_dir)
+        if not ret or not model_dir:
+            print(f"Error: Failed to download model or model path is invalid")
+            sys.exit(1)
     
     if not os.path.exists(model_dir):
-        print(f"Error: Model directory does not exist: {model_dir}")
-        sys.exit(1)
-    
+        print(f"Model directory does not exist: {model_dir}")
+        print(f"Attempting to download {args.model.upper()} model...")
+        ret = model_download(args.model, model_dir)
+        if not ret or not model_dir:
+            print(f"Error: Failed to download model")
+            sys.exit(1)
+
     # Load the corresponding model based on the selected model type
     print(f"Loading model: {args.model.upper()}")
     print(f"Model path: {model_dir}")

--- a/tools/launcher/utils/Install_LLM_Models.py
+++ b/tools/launcher/utils/Install_LLM_Models.py
@@ -12,7 +12,7 @@ from Install_Helper import *
 models = {
     "IBM-Granite-v3.1-8B": {
         "model_zip_url": "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models/models/ibm_granite_v3_1_8b_instruct/v1/snapdragon_x_elite/models.zip",
-        "tokenizer_url": "https://gitee.com/hf-models/granite-3.1-8b-base/raw/main/tokenizer.json"
+        "tokenizer_url": "https://huggingface.co/ibm-granite/granite-3.1-8b-base/resolve/main/tokenizer.json"
     }
 }
 

--- a/tools/launcher_linux/utils/Install_LLM_Models.py
+++ b/tools/launcher_linux/utils/Install_LLM_Models.py
@@ -12,7 +12,7 @@ from Install_Helper import *
 models = {
     "IBM-Granite-v3.1-8B": {
         "model_zip_url": "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models/models/ibm_granite_v3_1_8b_instruct/v1/snapdragon_x_elite/models.zip",
-        "tokenizer_url": "https://gitee.com/hf-models/granite-3.1-8b-base/raw/main/tokenizer.json"
+        "tokenizer_url": "https://huggingface.co/ibm-granite/granite-3.1-8b-base/resolve/main/tokenizer.json"
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes several bugs that surfaced when running the samples apps on Linux.

- Added `samples/models/multimodal/vision_language_model/qwen_vl/python/install_model.py`,
  a new helper module that downloads and extracts the Qwen2-VL / Qwen3-VL model
  archives (`download_qwen_models`) and validates required model files
  (`check_model_files`).
- Updated `qwen_vl.py` to import and use `install_model.py`: if no model path is
  supplied, or the given path does not exist, the script now attempts to download
  the corresponding model automatically instead of immediately failing.
- Updated `qwen_vl/README.md` to document the new `install_model.py` script and
  give explicit `--model qwen2` / `--model qwen3` usage examples.
- Added `Soc_ID_config()` to `stable_diffusion_v2_1.py` to allow the SoC id to be
  set before model initialization.
- Updated `StableDiffusionApp.py` to accept a `--soc_id` CLI argument, call
  `Soc_ID_config()` + `model_initialize()` at startup (moved out of the Gradio
  `Blocks` context), and use `os.path.join` for the output image directory
  instead of a hardcoded Windows path separator.
- Updated the Granite tokenizer URL in both
  `tools/launcher/utils/Install_LLM_Models.py` and
  `tools/launcher_linux/utils/Install_LLM_Models.py` to point directly to
  `https://huggingface.co/ibm-granite/granite-3.1-8b-base/resolve/main/tokenizer.json`
  instead of an unreliable Gitee mirror.

## Tests

- Manually verified `qwen_vl.py` falls back to `install_model.download_qwen_models()`
  when no model path is given / path does not exist.
- Manually verified `StableDiffusionApp.py` accepts `--soc_id` and initializes the
  model with the selected SoC before starting the Gradio server, and that the
  output image path resolves correctly on Linux (no backslash).
- Verified the updated tokenizer URL resolves via `huggingface.co`.

Closes #198
