### PR TITLE
Unify public QAI AppBuilder branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <br>
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/qualcomm/qai-appbuilder/main/docs/images/qai_banner.svg" alt="QAI AppBuilder & QAI ModelBuilder" width="900" height="150">
+  <img src="https://raw.githubusercontent.com/qualcomm/qai-appbuilder/main/docs/images/qai_banner.svg" alt="QAI AppBuilder" width="900" height="150">
 </div>
 
 <br>
@@ -60,15 +60,15 @@ every model ends up running on the same on-device NPU engine (`QNNContext` via
 
 ---
 
-### Get Started with QAI ModelBuilder
+### Get Started with QAI AppBuilder
 
-> **QAI ModelBuilder** is the natural-language Agent front-end of QAI AppBuilder — the App Builder,
+> **QAI AppBuilder** is the natural-language Agent platform for the App Builder,
 > Model Builder, and AI Hub Model Run capabilities described above all live here. Grab the
 > pre-built package below and you'll have a running, on-device AI app builder in **two commands**.
 
 <div align="center">
   <a href="https://github.com/qualcomm/qai-appbuilder/releases/download/v2.48.40/qaiappbuilder.zip">
-    <img src="https://img.shields.io/badge/Download-QAI%20ModelBuilder%20v3.0.0-2ea44f?style=for-the-badge" alt="Download QAI ModelBuilder">
+    <img src="https://img.shields.io/badge/Download-QAI%20AppBuilder%20v3.0.0-2ea44f?style=for-the-badge" alt="Download QAI AppBuilder">
   </a>
   &nbsp;&nbsp;
   <a href="https://github.com/qualcomm/qai-appbuilder/tree/main/tools/qaiappbuilder">
@@ -95,14 +95,14 @@ Setup.bat
 Start.bat
 ```
 
-Your browser opens the QAI ModelBuilder WebUI — start chatting to build an app, convert a model,
+Your browser opens the QAI AppBuilder WebUI — start chatting to build an app, convert a model,
 or run one straight from AI Hub.
 
-**Want to read or modify the code?** The complete QAI ModelBuilder project lives at
+**Want to read or modify the code?** The complete QAI AppBuilder project lives at
 [`tools/qaiappbuilder`](https://github.com/qualcomm/qai-appbuilder/tree/main/tools/qaiappbuilder).
 Clone the repo, then run `Setup.bat` → `Build.bat` → `Start.bat` to launch from source.
 
-> 📖 **Docs inside the QAI ModelBuilder project:**
+> 📖 **Docs inside the QAI AppBuilder project:**
 >
 > | Document | Description |
 > |----------|-------------|

--- a/docs/images/qai_banner.svg
+++ b/docs/images/qai_banner.svg
@@ -67,7 +67,7 @@
     <line x1="82" y1="64" x2="90" y2="64" stroke="#00c8ff" stroke-width="1.2"/>
   </g>
 
-  <!-- ═══ RIGHT: Model Conversion Pipeline (ModelBuilder) ═══ -->
+  <!-- ═══ RIGHT: Model Conversion Pipeline ═══ -->
   <g transform="translate(742, 22)" opacity="0.55">
     <!-- Box 1: ONNX/PyTorch source -->
     <rect x="0" y="18" width="36" height="26" rx="4"
@@ -130,14 +130,14 @@
   <!-- Blue underline -->
   <rect x="230" y="72" width="440" height="2" rx="1" fill="url(#blueAccent)" opacity="0.6"/>
 
-  <!-- ModelBuilder mention: bordered badge -->
+  <!-- Product summary badge -->
   <rect x="90" y="88" width="720" height="32" rx="16"
         fill="none" stroke="#3a6a9a" stroke-width="1" opacity="0.7"/>
   <text x="450" y="109" text-anchor="middle"
         font-family="'Segoe UI', Arial, sans-serif"
         font-size="13.5" font-weight="400" letter-spacing="0.5"
         fill="#a0c8e8">Powering
-    <tspan font-weight="700" fill="#f59e0b"> QAI ModelBuilder</tspan>
+    <tspan font-weight="700" fill="#f59e0b"> QAI AppBuilder</tspan>
     <tspan fill="#a0c8e8"> — Local-first AI Workspace · QNN Model Conversion · On-Device App Builder</tspan>
   </text>
 </svg>


### PR DESCRIPTION
## Summary
- replace obsolete QAI ModelBuilder product labels in the root README
- update the public banner to use QAI AppBuilder branding
- retain Model Builder as a feature name and keep internal identifiers unchanged

## Validation
- parsed docs/images/qai_banner.svg as XML
- confirmed linked QAI AppBuilder project documents exist
- confirmed README and banner contain no QAI ModelBuilder or QAIModelBuilder labels

Closes #206