### PR TITLE
Rename QAI AppBuilder project documentation

### DIFF
--- a/tools/qaiappbuilder/README.md
+++ b/tools/qaiappbuilder/README.md
@@ -1,4 +1,4 @@
-# 🤖 QAI ModelBuilder
+# 🤖 QAI AppBuilder
 
 > **A local-first AI workspace for Snapdragon® X-Series PCs — built on a clean DDD/Clean-Architecture core. Featuring an on-device App Builder workbench (ASR / TTS) running natively on the Snapdragon NPU, an AI-driven QNN Model Conversion & Optimization skill (Model Builder), multi-agent streaming chat, and a built Vue 3 WebUI.**
 
@@ -59,7 +59,7 @@
 
 ## 🏛️ Architecture Overview
 
-QAI ModelBuilder has been **fully rewritten as a Clean Architecture / DDD application**. The codebase is organized into bounded contexts under `src/qai/`, an application entry layer under `apps/`, a thin protocol-adapter layer under `interfaces/`, and out-of-the-box assets under `factory/`.
+QAI AppBuilder has been **fully rewritten as a Clean Architecture / DDD application**. The codebase is organized into bounded contexts under `src/qai/`, an application entry layer under `apps/`, a thin protocol-adapter layer under `interfaces/`, and out-of-the-box assets under `factory/`.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -192,7 +192,7 @@ Once you've converted a model with [`model-builder`](#-highlight-model-builder-s
 
 ## 🌟 Highlight: Model Builder Skill
 
-> **The most powerful feature of QAI ModelBuilder** — a built-in chat skill (`factory/chat_features/model-builder/`) that lets you convert, quantize, and validate AI models for the Qualcomm Snapdragon NPU through natural-language conversation, powered by cloud LLMs.
+> **A flagship capability of QAI AppBuilder** — a built-in chat skill (`factory/chat_features/model-builder/`) that lets you convert, quantize, and validate AI models for the Qualcomm Snapdragon NPU through natural-language conversation, powered by cloud LLMs.
 
 > ### ⚠️ Scope & Limitations
 >
@@ -388,7 +388,7 @@ After installation, double-click **`Start.bat`** (or launch the desktop app). Th
 ## 📁 Project Structure
 
 ```
-QAIModelBuilder/
+QAIAppBuilder/
 ├── apps/                 # Application entry layer
 │   ├── api/              #   FastAPI app factory (create_app), DI container, lifespan
 │   └── cli/              #   qai CLI + qai-serve supervisor
@@ -568,7 +568,7 @@ The **Sticky Worker** keeps the inference subprocess alive between runs on the s
 
 ## 📄 License
 
-QAI ModelBuilder is licensed under the BSD 3-Clause "New" or "Revised" License. See [LICENSE](LICENSE) for details.
+QAI AppBuilder is licensed under the BSD 3-Clause "New" or "Revised" License. See [LICENSE](LICENSE) for details.
 
 ---
 

--- a/tools/qaiappbuilder/README.zh-CN.md
+++ b/tools/qaiappbuilder/README.zh-CN.md
@@ -1,4 +1,4 @@
-# 🤖 QAI ModelBuilder
+# 🤖 QAI AppBuilder
 
 > **专为 Snapdragon® X-Series PC 打造的本地优先 AI 工作站，构建于干净的 DDD / Clean Architecture 内核之上。核心亮点包括：在骁龙 NPU 上原生运行的端侧 App Builder 工作台（ASR / TTS）、AI 驱动的 QNN 模型转换与优化技能（Model Builder）、多 Agent 流式聊天，以及构建型 Vue 3 WebUI。**
 
@@ -57,7 +57,7 @@
 
 ## 🏛️ 架构总览
 
-QAI ModelBuilder 已**全面重写为 Clean Architecture / DDD 应用**。代码按限界上下文组织于 `src/qai/`，应用入口层在 `apps/`，薄协议适配层在 `interfaces/`，出厂资产在 `factory/`。
+QAI AppBuilder 已**全面重写为 Clean Architecture / DDD 应用**。代码按限界上下文组织于 `src/qai/`，应用入口层在 `apps/`，薄协议适配层在 `interfaces/`，出厂资产在 `factory/`。
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -190,7 +190,7 @@ QAI ModelBuilder 已**全面重写为 Clean Architecture / DDD 应用**。代码
 
 ## 🌟 核心亮点：Model Builder 技能
 
-> **QAI ModelBuilder 最强大的功能** —— 一个内置聊天技能（`factory/chat_features/model-builder/`），让你借助云端 LLM，通过自然语言对话完成 AI 模型到高通骁龙 NPU 的转换、量化与验证全流程。
+> **QAI AppBuilder 的核心能力之一** —— 一个内置聊天技能（`factory/chat_features/model-builder/`），让你借助云端 LLM，通过自然语言对话完成 AI 模型到高通骁龙 NPU 的转换、量化与验证全流程。
 
 > ### ⚠️ 适用范围说明
 >
@@ -383,7 +383,7 @@ AI 会自动完成源模型下载、ONNX 导出、多精度转换、推理执行
 ## 📁 项目结构
 
 ```
-QAIModelBuilder/
+QAIAppBuilder/
 ├── apps/                 # 应用入口层
 │   ├── api/              #   FastAPI app 工厂（create_app）、DI 容器、lifespan
 │   └── cli/              #   qai CLI + qai-serve 监管器
@@ -563,7 +563,7 @@ use_for: 适用场景描述
 
 ## 📄 许可证
 
-QAI ModelBuilder 采用 BSD 3-Clause "New" or "Revised" License 授权。详情请查阅 [LICENSE](LICENSE) 文件。
+QAI AppBuilder 采用 BSD 3-Clause "New" or "Revised" License 授权。详情请查阅 [LICENSE](LICENSE) 文件。
 
 ---
 


### PR DESCRIPTION
## Summary
- rename public product references in the English and Chinese QAI AppBuilder subproject READMEs
- retain Model Builder as a feature name
- retain the existing QAIModelBuilder runtime-directory paths used by scripts

## Validation
- confirmed public product labels were removed from both README bodies
- confirmed linked subproject documentation files exist
- checked the Markdown diff for whitespace errors

Closes #208