### PR TITLE
fix: lower guard.zip MinSize threshold to match actual file size

### DIFF
--- a/tools/qaiappbuilder/Setup.bat
+++ b/tools/qaiappbuilder/Setup.bat
@@ -1480,7 +1480,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File "scripts\setup\download_
     -Url "%GUARD_URL%" ^
     -OutFile "%GUARD_ZIP%" ^
     -Aria2cExe "data\bin\aria2c\aria2c.exe" ^
-    -MinSize 500000 ^
+    -MinSize 300000 ^
     -ZipTest ^
     -MaxRetries 5 ^
     -StallTimeoutSec 60 ^


### PR DESCRIPTION
Closes #214

## Problem
Setup.bat Step 0c checks the downloaded guard.zip against a MinSize of 500000 bytes (488 KB). The actual file on the GitHub release is ~376 KB, so every download triggers 5 retry attempts with [ERROR] output before falling through to extraction -- even though the file is complete and extracts correctly.

## Fix
Lower MinSize from 500000 to 300000 bytes (293 KB). The actual file is ~376 KB, so this threshold catches genuinely truncated downloads while passing a complete one on the first attempt.

## Change
One line: tools/qaiappbuilder/Setup.bat, -MinSize 500000 -> -MinSize 300000.