### PR TITLE
fix: add paramiko to Setup.bat dependency completeness probe

### DIFF
--- a/tools/qaiappbuilder/Setup.bat
+++ b/tools/qaiappbuilder/Setup.bat
@@ -584,9 +584,9 @@ REM ``browserforge`` is probed for the same reason: it generates the dynamic
 REM per-request browser fingerprint the keyless scrapers use to evade bot
 REM detection (import-guarded, so its absence only drops back to a static
 REM header set), and ships a pure-Python wheel so probing it forces no rebuild.
-"%VENV_DIR%\Scripts\python.exe" -c "import fastapi, uvicorn, structlog, claude_agent_sdk, croniter, playwright, selectolax, lxml, browserforge" >nul 2>&1
+"%VENV_DIR%\Scripts\python.exe" -c "import fastapi, uvicorn, structlog, claude_agent_sdk, croniter, playwright, selectolax, lxml, browserforge, paramiko" >nul 2>&1
 if not errorlevel 1 (
-    echo [SKIP] Dependencies already installed and complete ^(fastapi, uvicorn, structlog, claude_agent_sdk, croniter, playwright^). Skipping pip steps.
+    echo [SKIP] Dependencies already installed and complete ^(fastapi, uvicorn, structlog, claude_agent_sdk, croniter, playwright, paramiko^). Skipping pip steps.
     goto :skip_all_installs
 )
 echo [INFO] Dependency closure incomplete or missing; running full install to ^(re^)complete it...


### PR DESCRIPTION
Closes #218

## Problem
PR #217 added paramiko to pyproject.toml but not to the Setup.bat dependency probe. The probe imports a fixed set of packages to detect a complete venv — if all pass, Setup.bat skips the pip install step. Existing venvs (with fastapi/uvicorn/etc. already installed) would take the [SKIP] branch and never install paramiko, causing ModuleNotFoundError on server startup.

## Fix
Add paramiko to the import probe (one line change). Any venv missing paramiko now falls through to the idempotent uv pip install step and self-heals.

## Workaround for existing installations
Run manually:
  uv pip install paramiko>=5.0 --python <venv>/Scripts/python.exe --system-certs