### PR TITLE
fix: 4 bugs found during deep review of SSH tunnel feature

### DIFF
--- a/tools/qaiappbuilder/frontend/src/components/chat/toolbar-modes/ModeFrameSsh.vue
+++ b/tools/qaiappbuilder/frontend/src/components/chat/toolbar-modes/ModeFrameSsh.vue
@@ -197,14 +197,6 @@ function openInstanceTunnel(host: string): void {
 
 // ── Actions ───────────────────────────────────────────────────────────────────
 async function onTestConnect(s: ServerDraft): Promise<void> {
-  await testConnect({
-    host: s.host,
-    ssh_port: s.sshPort,
-    username: s.username,
-    auth_method: s.authMethod,
-    auth_ref: s.authRef,
-    key_path: s.keyPath,
-  });
   const cr = getConnectResult(s.id);
   cr.connecting = true;
   cr.success = false;
@@ -212,7 +204,7 @@ async function onTestConnect(s: ServerDraft): Promise<void> {
   try {
     const ok = await testConnect({
       host: s.host,
-      ssh_port: 22,
+      ssh_port: s.sshPort,
       username: s.username,
       auth_method: s.authMethod,
       auth_ref: s.authRef,
@@ -231,16 +223,6 @@ async function onTestConnect(s: ServerDraft): Promise<void> {
 async function onDeploy(s: ServerDraft): Promise<void> {
   activeDeployId.value = s.id;
   s.showLog = true;
-  await deploy({
-    host: s.host,
-    ssh_port: s.sshPort,
-    username: s.username,
-    auth_method: s.authMethod,
-    auth_ref: s.authRef,
-    key_path: s.keyPath,
-    remote_port: s.remotePort,
-  });
-  activeDeployId.value = null;
   const ds = getDeployState(s.id);
   ds.log = [];
   ds.percent = 0;
@@ -249,12 +231,12 @@ async function onDeploy(s: ServerDraft): Promise<void> {
   try {
     await deploy({
       host: s.host,
-      ssh_port: 22,
+      ssh_port: s.sshPort,
       username: s.username,
       auth_method: s.authMethod,
       auth_ref: s.authRef,
       key_path: s.keyPath,
-      remote_port: 8989,
+      remote_port: s.remotePort,
     });
   } catch (err) {
     ds.error = err instanceof Error ? err.message : String(err);

--- a/tools/qaiappbuilder/frontend/src/composables/useSshRemote.ts
+++ b/tools/qaiappbuilder/frontend/src/composables/useSshRemote.ts
@@ -112,13 +112,12 @@ export function useSshRemote() {
       onProgress(data: unknown) {
         const d = data as DeployProgress;
         if (d.line) {
+          // Do NOT auto-open here: this line streams mid-deploy, before the
+          // local tunnel exists, and its URL is the (often unreachable)
+          // remote host — opening it races with the correct tunnel-aware
+          // open in deploy()'s post-SSE handling below, which waits for
+          // the local_url to be ready. See onDone / the try block below.
           deployLog.value.push(d.line);
-          // Auto-open browser when service is confirmed running
-          // Matches both fresh deploy and "already running" fast-path
-          const m = d.line.match(/\[done\].*?(https?:\/\/[^\s]+)/);
-          if (m) {
-            openRemoteUrl(m[1]!);
-          }
         }
         if (typeof d.percent === "number") deployPercent.value = d.percent;
       },

--- a/tools/qaiappbuilder/interfaces/http/routes/remote_deploy.py
+++ b/tools/qaiappbuilder/interfaces/http/routes/remote_deploy.py
@@ -226,7 +226,6 @@ def build_router(*, container: "Container") -> APIRouter:
                     )
                     instance.tunnel_state = "running"
                     await container.remote_deploy.repository.save(instance)
-                    import json
                     done_payload = json.dumps({
                         "instance_id": instance_id,
                         "remote_url": instance.remote_url,


### PR DESCRIPTION
Closes #222

Deep line-by-line re-review of the SSH remote-deploy code (beyond the merge-conflict fix in #221) found 4 additional real bugs:

## 1. remote_deploy.py — dead code
Redundant `import json` inside the deploy SSE generator (module-level import already exists at the top of the file).

## 2. useSshRemote.ts onProgress — premature URL open races with correct one
A regex matched streamed `[done]` log lines and opened the REMOTE host URL immediately — before the local tunnel exists. Raced with the correct tunnel-aware open at the end of `deploy()`. Result: two browser tabs opened, first an unreachable remote URL, then the correct local tunnel URL.

## 3. ModeFrameSsh.vue onTestConnect — wrong port tested (severe)
Two competing `testConnect()` calls left over from a bad merge: the first used the correct `s.sshPort` but was fire-and-forget (no UI update); the second — the one that actually drove the visible connect-result — was hardcoded to `ssh_port: 22`. A server configured with a non-default SSH port always showed the result for port 22 instead.

## 4. ModeFrameSsh.vue onDeploy — full deploy runs twice with wrong ports (severe)
Same pattern: two competing `deploy()` calls, the second hardcoded to `ssh_port: 22` / `remote_port: 8989`. Every 'Install & Start' click ran the entire deploy pipeline (clone/setup/build/start over SSH) TWICE, silently overriding any custom port configuration on the second run.

## Fix
Removed the dead first call in each pair; kept the properly state-managed block, fixed to use the server's actual `s.sshPort`/`s.remotePort` instead of hardcoded defaults.