### PR TITLE
Improve MeloTTS zh and PiperTTS en inference correctness across model releases

### DIFF
--- a/samples/models/audio/audio_generation/melotts_zh/python/melotts_zh.py
+++ b/samples/models/audio/audio_generation/melotts_zh/python/melotts_zh.py
@@ -254,6 +254,44 @@ MAX_DEC_SEQ_LEN       = 64
 UPSAMPLE_FACTOR       = 512
 SAMPLE_RATE           = 44100
 
+
+def _read_decoder_time_dim_from_metadata(model_dir):
+    """Read the decoder.bin ``z`` input time-dim (T) from metadata.json.
+
+    Dragon Bridge ``qai_modelbuilder_hotfix.py`` approach: the ground-truth
+    decoder shape ships in the model package's ``metadata.json``
+    (``model_files -> decoder.bin -> inputs -> z -> shape``).  Reading it is a
+    reliable fallback for when the live ``getInputShapes()`` probe is
+    unavailable or returns an unexpected layout, so we never fall back to a
+    stale compiled-in constant that would produce wrong-length / corrupted
+    audio against a differently-shaped release.
+
+    Returns the integer T, or ``None`` if metadata.json is absent / malformed
+    (never raises — a failed read must not break synthesis).
+    """
+    import json
+
+    meta_path = os.path.join(model_dir, "metadata.json")
+    if not os.path.isfile(meta_path):
+        return None
+    try:
+        with open(meta_path, encoding="utf-8") as f:
+            metadata = json.load(f)
+        shape = (
+            metadata.get("model_files", {})
+            .get("decoder.bin", {})
+            .get("inputs", {})
+            .get("z", {})
+            .get("shape")
+        )
+        if isinstance(shape, (list, tuple)) and len(shape) >= 1:
+            t = int(shape[-1])
+            if t > 0:
+                return t
+    except Exception as e:  # pylint: disable=broad-except
+        print(f"[WARN] Could not read decoder z time-dim from metadata.json ({e}).")
+    return None
+
 # ── 5. QNN model wrappers ──────────────────────────────────────────────────────
 class EncoderModel(QNNContext):
     """float32 I/O"""
@@ -330,6 +368,44 @@ decoder_model = DecoderModel(
     input_data_type="native", output_data_type="native",
 )
 print("[INFO] All models loaded.")
+
+# ── Resolve the decoder's real z time-dim (do NOT hardcode) ───────────────────
+# decoder.bin expects z shaped [1, 192, T].  Different AI Hub releases compile
+# different T (public v0.55/v0.56 ZIPs use T=64; the App-Builder "full" variant
+# uses T=128).  Hardcoding MAX_DEC_SEQ_LEN=64 against a T=128 binary silently
+# produces wrong-length / corrupted audio.  Resolve T in three tiers, each more
+# authoritative than the next fallback:
+#   1. live getInputShapes() probe of the loaded decoder (actual binary);
+#   2. metadata.json shipped in the model package (Dragon Bridge hotfix);
+#   3. the compiled-in constant (last resort only).
+DEC_SEQ_LEN = None
+_dec_seq_src = None
+try:
+    _dec_shapes = decoder_model.getInputShapes()
+    for _s in _dec_shapes:
+        # z is the 3-D input whose feature dim is 192; its last dim is T.
+        if len(_s) == 3 and _s[1] == 192:
+            DEC_SEQ_LEN = int(_s[2])
+            _dec_seq_src = "getInputShapes() probe"
+            break
+except Exception as _e:  # pylint: disable=broad-except
+    print(f"[WARN] Could not probe decoder z time-dim ({_e}); trying metadata.json ...")
+
+if DEC_SEQ_LEN is None:
+    _meta_t = _read_decoder_time_dim_from_metadata(MODEL_DIR)
+    if _meta_t is not None:
+        DEC_SEQ_LEN = _meta_t
+        _dec_seq_src = "metadata.json"
+
+if DEC_SEQ_LEN is None:
+    DEC_SEQ_LEN = MAX_DEC_SEQ_LEN
+    _dec_seq_src = "compiled constant (fallback)"
+
+if DEC_SEQ_LEN != MAX_DEC_SEQ_LEN:
+    print(f"[INFO] Decoder z time-dim resolved as T={DEC_SEQ_LEN} via {_dec_seq_src} "
+          f"(compiled constant was {MAX_DEC_SEQ_LEN}); using resolved value.")
+else:
+    print(f"[INFO] Decoder z time-dim T={DEC_SEQ_LEN} via {_dec_seq_src} (matches constant).")
 
 # ── 9. Text preprocessing ──────────────────────────────────────────────────────
 def preprocess_text(text):
@@ -423,10 +499,12 @@ def synthesize(text: str, output_path: str,
         print("[TTS] Step 4/4: Decoder (chunked)...")
         audio_chunks = []
         z_total = z.shape[2]  # 1536
-        for start in range(0, z_total, MAX_DEC_SEQ_LEN):
-            end = start + MAX_DEC_SEQ_LEN
+        # Use the runtime-resolved decoder time-dim (DEC_SEQ_LEN) rather than the
+        # compiled-in MAX_DEC_SEQ_LEN so we stay correct across model releases.
+        for start in range(0, z_total, DEC_SEQ_LEN):
+            end = start + DEC_SEQ_LEN
             if end > z_total:
-                z_slice = np.zeros([1, z.shape[1], MAX_DEC_SEQ_LEN], dtype=np.float32)
+                z_slice = np.zeros([1, z.shape[1], DEC_SEQ_LEN], dtype=np.float32)
                 z_slice[:, :, : z_total - start] = z[:, :, start:z_total]
             else:
                 z_slice = z[:, :, start:end]

--- a/samples/models/audio/audio_generation/pipertts_en/python/pipertts_en.py
+++ b/samples/models/audio/audio_generation/pipertts_en/python/pipertts_en.py
@@ -228,14 +228,27 @@ _PUNCT_MAP = {
 def text_to_piper_ids(text: str, lang: str = "en-us",
                       verbose: bool = False) -> np.ndarray:
     """
-    Text -> piper phoneme ids (BOS + phonemes + EOS).
-    Uses gruut for G2P (espeak-ng compatible, pure Python).
-    Format: BOS word1 SPACE PUNCT SPACE word2 EOS
+    Text -> piper phoneme ids, matching rhasspy/piper-phonemize exactly.
+
+    The Qualcomm PiperTTS acoustic model (encoder.bin) was trained on phoneme-id
+    sequences produced by piper_phonemize.phoneme_ids_espeak, i.e. piper's
+    phonemes_to_ids() with the default config:
+        addBos=True, addEos=True, interspersePad=True (pad='_'=0)
+    producing:  [BOS, PAD, p1, PAD, p2, PAD, ..., pN, PAD, EOS]
+    piper_phonemize has NO win-arm64 wheel, so we phonemize with gruut and then
+    reproduce piper's id assembly (incl. the interspersed PAD, whose earlier
+    omission garbled every sentence except the single tuned demo string).
+    espeak/piper iterate phonemes per Unicode codepoint over NFD-normalised
+    text, so we NFD-normalise and split multi-codepoint gruut phonemes.
     """
+    import unicodedata
+
     try:
         import gruut
     except ImportError:
         raise ImportError("gruut not installed. Run: pip install gruut")
+
+    PAD_ID = PIPER_PHONEME_ID_MAP['_']  # 0
 
     # Collect (word_text, phonemes_list, is_break) entries
     word_entries = []
@@ -250,49 +263,58 @@ def text_to_piper_ids(text: str, lang: str = "en-us",
             break_marker = " [BREAK]" if is_break else ""
             print(f"    {repr(wt):20s} -> {ph}{break_marker}")
 
-    # Map to piper ids
-    ids = [PIPER_BOS_ID]
+    # -- Step 1: flat list of single-phoneme ids (NO bos/eos/pad yet) ----------
+    units = []          # list[int] — one entry per phoneme codepoint
     skipped = []
-    prev_was_word = False  # track whether to insert space between words
+    prev_was_word = False
+
+    def _emit_codepoints(token):
+        """Map a (possibly multi-codepoint) phoneme string to ids, one id per
+        mapped codepoint, matching piper's per-codepoint iteration."""
+        emitted = False
+        for ch in unicodedata.normalize("NFD", token):
+            if ch in _GRUUT_SKIP_CHARS:
+                continue
+            if ch in PIPER_PHONEME_ID_MAP:
+                units.append(PIPER_PHONEME_ID_MAP[ch])
+                emitted = True
+            else:
+                skipped.append(repr(ch))
+        return emitted
 
     for word_text, phonemes, is_break in word_entries:
         if is_break:
             # Punctuation word: SPACE PUNCT SPACE
             if prev_was_word:
-                ids.append(PIPER_PHONEME_ID_MAP[' '])
+                units.append(PIPER_PHONEME_ID_MAP[' '])
             for ch in word_text:
                 if ch in _PUNCT_MAP:
-                    ids.append(_PUNCT_MAP[ch])
-            ids.append(PIPER_PHONEME_ID_MAP[' '])
+                    units.append(_PUNCT_MAP[ch])
+            units.append(PIPER_PHONEME_ID_MAP[' '])
             prev_was_word = False
         else:
             # Regular word: insert space between adjacent words
             if prev_was_word:
-                ids.append(PIPER_PHONEME_ID_MAP[' '])
-            # Map phonemes one by one
+                units.append(PIPER_PHONEME_ID_MAP[' '])
             for p in phonemes:
                 if p in _GRUUT_BOUNDARY_MAP:
-                    ids.append(_GRUUT_BOUNDARY_MAP[p])
+                    units.append(_GRUUT_BOUNDARY_MAP[p])
                 elif p in PIPER_PHONEME_ID_MAP:
-                    ids.append(PIPER_PHONEME_ID_MAP[p])
+                    units.append(PIPER_PHONEME_ID_MAP[p])
                 else:
-                    # Decompose char by char (e.g. 'oU' -> 'o'=27, 'U'=100)
-                    found_any = False
-                    for ch in p:
-                        if ch in _GRUUT_SKIP_CHARS:
-                            continue  # silently skip combining tie
-                        if ch in PIPER_PHONEME_ID_MAP:
-                            ids.append(PIPER_PHONEME_ID_MAP[ch])
-                            found_any = True
-                        else:
-                            skipped.append(repr(ch))
-                    if not found_any:
+                    if not _emit_codepoints(p):
                         skipped.append(repr(p))
             prev_was_word = True
 
-    # Remove trailing space
-    while ids and ids[-1] == PIPER_PHONEME_ID_MAP[' ']:
-        ids.pop()
+    # Trim trailing word separators (space) before EOS.
+    while units and units[-1] == PIPER_PHONEME_ID_MAP[' ']:
+        units.pop()
+
+    # -- Step 2: piper phonemes_to_ids assembly (bos + interspersed pad) -------
+    ids = [PIPER_BOS_ID, PAD_ID]
+    for u in units:
+        ids.append(u)
+        ids.append(PAD_ID)   # pad after every phoneme (interspersePad=True)
     ids.append(PIPER_EOS_ID)
 
     if verbose:


### PR DESCRIPTION
## Summary

Optimize the inference code of two audio-generation TTS samples so both models
produce correct audio across model releases and match the training-time
tokenization.

- `samples/models/audio/audio_generation/melotts_zh/python/melotts_zh.py`
- `samples/models/audio/audio_generation/pipertts_en/python/pipertts_en.py`

## melotts_zh: runtime-resolved decoder time-dim (T)

`decoder.bin` expects `z` shaped `[1, 192, T]`. Different AI Hub releases compile
a different `T` (public v0.55/v0.56 ZIPs use `T=64`; the App-Builder "full"
variant uses `T=128`). The sample previously hardcoded `MAX_DEC_SEQ_LEN = 64`
and chunked the decoder by that constant, so running against a `T=128` binary
silently produced wrong-length / corrupted audio.

**Fix** — resolve the real decoder `z` time-dim at runtime in three tiers, most
authoritative first:
1. live `getInputShapes()` probe of the loaded decoder (the actual binary);
2. `metadata.json` shipped in the model package
   (`model_files -> decoder.bin -> inputs -> z -> shape`);
3. the compiled-in constant (last resort only, with an INFO/WARN log).

The decoder chunking loop now uses the resolved `DEC_SEQ_LEN` instead of
`MAX_DEC_SEQ_LEN`. The metadata read never raises (a failed read must not break
synthesis).

## pipertts_en: piper-accurate phoneme-id assembly

The Qualcomm PiperTTS acoustic model (`encoder.bin`) was trained on phoneme-id
sequences produced by `piper_phonemize.phoneme_ids_espeak`, i.e. piper's
`phonemes_to_ids()` with `addBos=True, addEos=True, interspersePad=True`
(pad `'_'` = 0), producing `[BOS, PAD, p1, PAD, p2, PAD, ..., pN, PAD, EOS]`.
`piper_phonemize` has no win-arm64 wheel, so the sample phonemizes with gruut,
but it previously omitted the interspersed PAD — which garbled every sentence
except the single tuned demo string.

**Fix** — reproduce piper's id assembly exactly:
- build a flat list of single-phoneme ids first (no BOS/EOS/PAD yet);
- NFD-normalise and iterate phonemes per Unicode codepoint (as espeak/piper do),
  splitting multi-codepoint gruut phonemes;
- trim trailing word separators, then assemble
  `[BOS, PAD]` + `(phoneme, PAD)` per unit + `[EOS]`.

## Testing

- MeloTTS (zh): verified correct-length, non-corrupted audio against both a
  `T=64` and a `T=128` decoder binary; the resolved `DEC_SEQ_LEN` matches the
  loaded binary and is logged with its source tier.
- PiperTTS (en): verified intelligible audio on multiple sentences (not just the
  original tuned demo string), matching piper-phonemize id sequences.

Fixes #231
