### PR TITLE
feat: multi-graph support for weight-shared context binaries

### DIFF
--- a/pybind/AppBuilder.cpp
+++ b/pybind/AppBuilder.cpp
@@ -23,10 +23,10 @@ ShareMemory::~ShareMemory() {
 
 QNNContext::QNNContext(const std::string& model_name,
                        const std::string& model_path, const std::string& backend_lib_path, const std::string& system_lib_path, 
-                       bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID, std::string coreIdsStr) {
+                       bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID, std::string coreIdsStr, const std::vector<std::string>& enable_graphs) {
     m_model_name = model_name;
 
-    g_LibAppBuilder.ModelInitialize(model_name, model_path, backend_lib_path, system_lib_path, async, input_data_type, output_data_type, deviceID, coreIdsStr);
+    g_LibAppBuilder.ModelInitialize(model_name, model_path, backend_lib_path, system_lib_path, async, input_data_type, output_data_type, deviceID, coreIdsStr, enable_graphs);
 }
 
 QNNContext::QNNContext(const std::string& model_name, const std::string& proc_name,
@@ -41,12 +41,12 @@ QNNContext::QNNContext(const std::string& model_name, const std::string& proc_na
 QNNContext::QNNContext(const std::string& model_name,
                        const std::string& model_path, const std::string& backend_lib_path, 
                        const std::string& system_lib_path, const std::vector<LoraAdapter>& lora_adapters, 
-                       bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID, std::string coreIdsStr) {
-    
+                       bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID, std::string coreIdsStr, const std::vector<std::string>& enable_graphs) {
+
     m_model_name = model_name;
     m_lora_adapters = lora_adapters;
 
-    g_LibAppBuilder.ModelInitialize(model_name, model_path, backend_lib_path, system_lib_path, m_lora_adapters, async, input_data_type, output_data_type, deviceID, coreIdsStr);
+    g_LibAppBuilder.ModelInitialize(model_name, model_path, backend_lib_path, system_lib_path, m_lora_adapters, async, input_data_type, output_data_type, deviceID, coreIdsStr, enable_graphs);
 }
 
 // issue#24
@@ -270,8 +270,8 @@ PYBIND11_MODULE(appbuilder, m) {
         .def(py::init<const std::string&, const size_t>());
 
     py::class_<QNNContext>(m, "QNNContext")
-        .def(py::init<const std::string&, const std::string&, const std::string&, const std::string&, bool, const std::string&, const std::string&, uint32_t, std::string>())
-        .def(py::init<const std::string&, const std::string&, const std::string&, const std::string&, const std::vector<LoraAdapter>&, bool, const std::string&, const std::string&, uint32_t, std::string>())
+        .def(py::init<const std::string&, const std::string&, const std::string&, const std::string&, bool, const std::string&, const std::string&, uint32_t, std::string, const std::vector<std::string>&>())
+        .def(py::init<const std::string&, const std::string&, const std::string&, const std::string&, const std::vector<LoraAdapter>&, bool, const std::string&, const std::string&, uint32_t, std::string, const std::vector<std::string>&>())
         .def(py::init<const std::string&, const std::string&, const std::string&, const std::string&, const std::string&, bool, const std::string&, const std::string&, uint32_t, std::string>())
         .def("Inference", py::overload_cast<const std::vector<py::array>&, const std::string&, size_t, const std::string&, const std::string&>(&QNNContext::Inference))
         .def("Inference", py::overload_cast<const ShareMemory&, const std::vector<py::array>&, const std::string&, size_t, const std::string&, const std::string&>(&QNNContext::Inference))

--- a/pybind/AppBuilder.cpp
+++ b/pybind/AppBuilder.cpp
@@ -50,32 +50,32 @@ QNNContext::QNNContext(const std::string& model_name,
 }
 
 // issue#24
-std::vector<std::vector<size_t>> QNNContext::getInputShapes(){
-    return g_LibAppBuilder.getInputShapes(m_model_name);
+std::vector<std::vector<size_t>> QNNContext::getInputShapes(size_t graphIdx){
+    return g_LibAppBuilder.getInputShapes(m_model_name, graphIdx);
 };
 
-std::vector<std::string> QNNContext::getInputDataType(){
-    return g_LibAppBuilder.getInputDataType(m_model_name);
+std::vector<std::string> QNNContext::getInputDataType(size_t graphIdx){
+    return g_LibAppBuilder.getInputDataType(m_model_name, graphIdx);
 };
 
-std::vector<std::vector<size_t>> QNNContext::getOutputShapes(){
-    return g_LibAppBuilder.getOutputShapes(m_model_name);
+std::vector<std::vector<size_t>> QNNContext::getOutputShapes(size_t graphIdx){
+    return g_LibAppBuilder.getOutputShapes(m_model_name, graphIdx);
 };
 
-std::vector<std::string> QNNContext::getOutputDataType(){
-    return g_LibAppBuilder.getOutputDataType(m_model_name);
+std::vector<std::string> QNNContext::getOutputDataType(size_t graphIdx){
+    return g_LibAppBuilder.getOutputDataType(m_model_name, graphIdx);
 };
 
-std::string  QNNContext::getGraphName(){
-    return g_LibAppBuilder.getGraphName(m_model_name);
+std::string  QNNContext::getGraphName(size_t graphIdx){
+    return g_LibAppBuilder.getGraphName(m_model_name, graphIdx);
 };
 
-std::vector<std::string> QNNContext::getInputName(){
-    return g_LibAppBuilder.getInputName(m_model_name);
+std::vector<std::string> QNNContext::getInputName(size_t graphIdx){
+    return g_LibAppBuilder.getInputName(m_model_name, graphIdx);
 };
 
-std::vector<std::string> QNNContext::getOutputName(){
-    return g_LibAppBuilder.getOutputName(m_model_name);
+std::vector<std::string> QNNContext::getOutputName(size_t graphIdx){
+    return g_LibAppBuilder.getOutputName(m_model_name, graphIdx);
 };
 
 std::vector<std::vector<size_t>> QNNContext::getInputShapes(const std::string& proc_name){
@@ -283,13 +283,20 @@ PYBIND11_MODULE(appbuilder, m) {
              py::arg("request_id"), py::arg("share_memory"),
              py::arg("output_data_type") = "float")
         .def("ApplyBinaryUpdate", &QNNContext::ApplyBinaryUpdate, "Apply Lora binary update")
-        .def("getInputShapes", py::overload_cast<>(&QNNContext::getInputShapes)) 
-        .def("getInputDataType", py::overload_cast<>(&QNNContext::getInputDataType)) 
-        .def("getOutputShapes", py::overload_cast<>(&QNNContext::getOutputShapes)) 
-        .def("getOutputDataType", py::overload_cast<>(&QNNContext::getOutputDataType)) 
-        .def("getInputName", py::overload_cast<>(&QNNContext::getInputName))
-        .def("getOutputName", py::overload_cast<>(&QNNContext::getOutputName))
-        .def("getGraphName", py::overload_cast<>(&QNNContext::getGraphName)) 
+        .def("getInputShapes", py::overload_cast<size_t>(&QNNContext::getInputShapes),
+             py::arg("graphIdx") = 0)
+        .def("getInputDataType", py::overload_cast<size_t>(&QNNContext::getInputDataType),
+             py::arg("graphIdx") = 0)
+        .def("getOutputShapes", py::overload_cast<size_t>(&QNNContext::getOutputShapes),
+             py::arg("graphIdx") = 0)
+        .def("getOutputDataType", py::overload_cast<size_t>(&QNNContext::getOutputDataType),
+             py::arg("graphIdx") = 0)
+        .def("getInputName", py::overload_cast<size_t>(&QNNContext::getInputName),
+             py::arg("graphIdx") = 0)
+        .def("getOutputName", py::overload_cast<size_t>(&QNNContext::getOutputName),
+             py::arg("graphIdx") = 0)
+        .def("getGraphName", py::overload_cast<size_t>(&QNNContext::getGraphName),
+             py::arg("graphIdx") = 0)
         .def("getInputShapes", py::overload_cast<const std::string&>(&QNNContext::getInputShapes))
         .def("getInputDataType", py::overload_cast<const std::string&>(&QNNContext::getInputDataType))
         .def("getOutputDataType", py::overload_cast<const std::string&>(&QNNContext::getOutputDataType))

--- a/pybind/AppBuilder.h
+++ b/pybind/AppBuilder.h
@@ -435,10 +435,10 @@ public:
     std::vector<LoraAdapter> m_lora_adapters;  
 
     QNNContext(const std::string& model_name, const std::string& model_path, const std::string& backend_lib_path, const std::string& system_lib_path, 
-               bool async = false, const std::string& input_data_type="float", const std::string& output_data_type="float", uint32_t deviceID=0, std::string coreIdsStr="");
+               bool async = false, const std::string& input_data_type="float", const std::string& output_data_type="float", uint32_t deviceID=0, std::string coreIdsStr="", const std::vector<std::string>& enable_graphs={});
 
     QNNContext(const std::string& model_name, const std::string& model_path, const std::string& backend_lib_path, const std::string& system_lib_path, const std::vector<LoraAdapter>& lora_adapters, 
-               bool async = false, const std::string& input_data_type="float", const std::string& output_data_type="float", uint32_t deviceID=0, std::string coreIdsStr="");   
+               bool async = false, const std::string& input_data_type="float", const std::string& output_data_type="float", uint32_t deviceID=0, std::string coreIdsStr="", const std::vector<std::string>& enable_graphs={});
 
     QNNContext(const std::string& model_name, const std::string& proc_name, const std::string& model_path, const std::string& backend_lib_path, const std::string& system_lib_path, 
                bool async = false, const std::string& input_data_type="float", const std::string& output_data_type="float", uint32_t deviceID=0, std::string coreIdsStr="");

--- a/pybind/AppBuilder.h
+++ b/pybind/AppBuilder.h
@@ -262,9 +262,9 @@ std::vector<py::array> inference(std::string model_name, const std::vector<py::a
     //QNN_INF("inference::inference output vector length: %d\n", outputBuffers.size());
 
     // dtype list like: ['float16', 'float16', ...]
-    std::vector<std::string> outDtypes = g_LibAppBuilder.getOutputDataType(model_name);
+    std::vector<std::string> outDtypes = g_LibAppBuilder.getOutputDataType(model_name, graphIndex);
     // output shapes for robust element count & float/native dtype inference
-    std::vector<std::vector<size_t>> outShapes = g_LibAppBuilder.getOutputShapes(model_name);
+    std::vector<std::vector<size_t>> outShapes = g_LibAppBuilder.getOutputShapes(model_name, graphIndex);
 
     std::vector<py::array> output;
 
@@ -455,13 +455,13 @@ public:
     bool ApplyBinaryUpdate(const std::vector<LoraAdapter>& lora_adapters);
 
     // issue#24
-    std::vector<std::vector<size_t>> getInputShapes();
-    std::vector<std::string>  getInputDataType();
-    std::vector<std::string>  getOutputDataType();
-    std::vector<std::vector<size_t>> getOutputShapes();
-    std::string getGraphName();
-    std::vector<std::string>  getInputName();
-    std::vector<std::string>  getOutputName();
+    std::vector<std::vector<size_t>> getInputShapes(size_t graphIdx);
+    std::vector<std::string>  getInputDataType(size_t graphIdx);
+    std::vector<std::string>  getOutputDataType(size_t graphIdx);
+    std::vector<std::vector<size_t>> getOutputShapes(size_t graphIdx);
+    std::string getGraphName(size_t graphIdx);
+    std::vector<std::string>  getInputName(size_t graphIdx);
+    std::vector<std::string>  getOutputName(size_t graphIdx);
 
     std::vector<std::vector<size_t>> getInputShapes(const std::string& proc_name);
     std::vector<std::string>  getInputDataType(const std::string& proc_name);

--- a/script/qai_appbuilder/qnncontext.py
+++ b/script/qai_appbuilder/qnncontext.py
@@ -494,25 +494,25 @@ class OnnxRuntimeContext:
 
         return self.session.run([o.name for o in self._outputs], feed)
 
-    def getInputShapes(self):
+    def getInputShapes(self, graph_index: int = 0):
         return [self._shape_list(i.shape) for i in self._inputs]
 
-    def getOutputShapes(self):
+    def getOutputShapes(self, graph_index: int = 0):
         return [self._shape_list(o.shape) for o in self._outputs]
 
-    def getInputDataType(self):
+    def getInputDataType(self, graph_index: int = 0):
         return [_onnx_dtype_to_simple(i.type) for i in self._inputs]
 
-    def getOutputDataType(self):
+    def getOutputDataType(self, graph_index: int = 0):
         return [_onnx_dtype_to_simple(o.type) for o in self._outputs]
 
-    def getGraphName(self):
+    def getGraphName(self, graph_index: int = 0):
         return self.model_name
 
-    def getInputName(self):
+    def getInputName(self, graph_index: int = 0):
         return [i.name for i in self._inputs]
 
-    def getOutputName(self):
+    def getOutputName(self, graph_index: int = 0):
         return [o.name for o in self._outputs]
 
     def getProfilingEvent(self, eventType):
@@ -713,44 +713,44 @@ class _QNNContextBase:
                 f"'{getattr(self, 'model_name', '<unknown>')}' has been released."
             )
 
-    def _call_ctx_getter(self, method_name: str):
+    def _call_ctx_getter(self, method_name: str, graph_index: int = 0):
         self._ensure_live(method_name)
         method = getattr(self.m_context, method_name)
         if hasattr(self, "proc_name"):
             return method(self.proc_name)
-        return method()
+        return method(graph_index)
 
     # issue#24
-    def getInputShapes(self):
-        return self._call_ctx_getter("getInputShapes")
+    def getInputShapes(self, graph_index: int = 0):
+        return self._call_ctx_getter("getInputShapes", graph_index)
 
-    def getOutputShapes(self):
-        return self._call_ctx_getter("getOutputShapes")
+    def getOutputShapes(self, graph_index: int = 0):
+        return self._call_ctx_getter("getOutputShapes", graph_index)
 
-    def getInputDataType(self):
-        return self._call_ctx_getter("getInputDataType")
+    def getInputDataType(self, graph_index: int = 0):
+        return self._call_ctx_getter("getInputDataType", graph_index)
 
-    def getOutputDataType(self):
-        return self._call_ctx_getter("getOutputDataType")
+    def getOutputDataType(self, graph_index: int = 0):
+        return self._call_ctx_getter("getOutputDataType", graph_index)
 
-    def getGraphName(self):
-        return self._call_ctx_getter("getGraphName")
+    def getGraphName(self, graph_index: int = 0):
+        return self._call_ctx_getter("getGraphName", graph_index)
 
-    def getInputName(self):
-        return self._call_ctx_getter("getInputName")
+    def getInputName(self, graph_index: int = 0):
+        return self._call_ctx_getter("getInputName", graph_index)
 
-    def getOutputName(self):
-        return self._call_ctx_getter("getOutputName")
+    def getOutputName(self, graph_index: int = 0):
+        return self._call_ctx_getter("getOutputName", graph_index)
     
     def getProfilingEvent(self, eventType):
         self._ensure_live("getProfilingEvent")
         return self.m_context.getProfilingEvent(eventType)
 
-    def _inference_and_reshape(self, input, infer_fn):
+    def _inference_and_reshape(self, input, infer_fn, graph_index: int = 0):
         self._ensure_live("Inference")
         input = reshape_input(input)
         output = infer_fn(input)
-        outputshape_list = self.getOutputShapes()
+        outputshape_list = self.getOutputShapes(graph_index)
         output = reshape_output(output, outputshape_list)
         return output
 
@@ -836,7 +836,8 @@ class QNNContext(_QNNContextBase):
 
         return self._inference_and_reshape(
             input,
-            lambda _in: self.m_context.Inference(_in, perf_profile, graphIndex, self.input_data_type, self.output_data_type)
+            lambda _in: self.m_context.Inference(_in, perf_profile, graphIndex, self.input_data_type, self.output_data_type),
+            graph_index=graphIndex
         )
 
     def isOnnxModel(self):
@@ -969,7 +970,8 @@ class QNNLoraContext(_QNNContextBase):
     def Inference(self, input, perf_profile=PerfProfile.DEFAULT, graphIndex=0):
         return self._inference_and_reshape(
             input,
-            lambda _in: self.m_context.Inference(_in, perf_profile, graphIndex, self.input_data_type, self.output_data_type)
+            lambda _in: self.m_context.Inference(_in, perf_profile, graphIndex, self.input_data_type, self.output_data_type),
+            graph_index=graphIndex
         )
 
     def apply_binary_update(self, lora_adapters=None):

--- a/script/qai_appbuilder/qnncontext.py
+++ b/script/qai_appbuilder/qnncontext.py
@@ -802,7 +802,8 @@ class QNNContext(_QNNContextBase):
                  input_data_type: str = DataType.FLOAT,
                  output_data_type: str = DataType.FLOAT,
                  deviceID: int = 0,
-                 coreIdsStr: str = "None"
+                 coreIdsStr: str = "None",
+                 enable_graphs=None
                  ) -> None:
         """Load a QNN model from `model_path`
         Args:
@@ -825,7 +826,7 @@ class QNNContext(_QNNContextBase):
         backend_lib_path, system_lib_path = self._resolve_lib_paths(backend_lib_path, system_lib_path)
 
         self.m_context = appbuilder.QNNContext(model_name, model_path, backend_lib_path, system_lib_path,
-                                              is_async, input_data_type, output_data_type, deviceID, coreIdsStr)
+                                              is_async, input_data_type, output_data_type, deviceID, coreIdsStr, list(enable_graphs) if enable_graphs else [])
         _register_context(self)
 
     #@timer
@@ -939,7 +940,8 @@ class QNNLoraContext(_QNNContextBase):
                  input_data_type: str = DataType.FLOAT,
                  output_data_type: str = DataType.FLOAT,
                  deviceID: int = 0,
-                 coreIdsStr: str = "None"
+                 coreIdsStr: str = "None",
+                 enable_graphs=None
                  ) -> None:
         """Load a QNN model from `model_path`
         Args:
@@ -963,7 +965,7 @@ class QNNLoraContext(_QNNContextBase):
         backend_lib_path, system_lib_path = self._resolve_lib_paths(backend_lib_path, system_lib_path)
 
         self.m_context = appbuilder.QNNContext(model_name, model_path, backend_lib_path, system_lib_path, m_lora_adapters,
-                                              is_async, input_data_type, output_data_type, deviceID, coreIdsStr)
+                                              is_async, input_data_type, output_data_type, deviceID, coreIdsStr, list(enable_graphs) if enable_graphs else [])
         _register_context(self)
 
     #@timer

--- a/src/LibAppBuilder.cpp
+++ b/src/LibAppBuilder.cpp
@@ -455,7 +455,7 @@ void split(std::vector<std::string> &splitString,
 bool ModelInitializeEx(const std::string& model_name, const std::string& proc_name, const std::string& model_path,
                        const std::string& backend_lib_path, const std::string& system_lib_path, 
                        std::vector<LoraAdapter>& lora_adapters,
-                       bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID=0, std::string coreIdsStr="") {
+                       bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID=0, std::string coreIdsStr="", const std::vector<std::string>& enable_graphs={}) {
   QNN_INFO("LibAppBuilder::ModelInitialize: %s \n", model_name.c_str());
 
   bool result = false;
@@ -538,6 +538,10 @@ bool ModelInitializeEx(const std::string& model_name, const std::string& proc_na
     if (nullptr == app) {
       return false;
     }
+
+    // Must be set before createFromBinary(), which is where the selection is
+    // turned into a context config.
+    app->setEnabledGraphs(enable_graphs);
 
     QNN_INFO("LibAppBuilder   build version: %s", qnn::tools::getBuildId().c_str());
     QNN_INFO("Backend        build version: %s", app->getBackendBuildId().c_str());
@@ -733,16 +737,16 @@ bool LibAppBuilder::ModelInitialize(const std::string& model_name, const std::st
 
 bool LibAppBuilder::ModelInitialize(const std::string& model_name, const std::string& model_path,
                                     const std::string& backend_lib_path, const std::string& system_lib_path,
-                                    bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID, std::string coreIdsStr) {
+                                    bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID, std::string coreIdsStr, const std::vector<std::string>& enable_graphs) {
     std::vector<LoraAdapter> Adapters = std::vector<LoraAdapter>();
-    return ModelInitializeEx(model_name, "", model_path, backend_lib_path, system_lib_path, Adapters, async, input_data_type, output_data_type, deviceID, coreIdsStr);   
+    return ModelInitializeEx(model_name, "", model_path, backend_lib_path, system_lib_path, Adapters, async, input_data_type, output_data_type, deviceID, coreIdsStr, enable_graphs);
 }
 
 bool LibAppBuilder::ModelInitialize(const std::string& model_name, const std::string& model_path,
                                     const std::string& backend_lib_path, const std::string& system_lib_path,
                                     std::vector<LoraAdapter>& lora_adapters,
-                                    bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID, std::string coreIdsStr) {
-    return ModelInitializeEx(model_name, "", model_path, backend_lib_path, system_lib_path, lora_adapters, async, input_data_type, output_data_type, deviceID, coreIdsStr);
+                                    bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID, std::string coreIdsStr, const std::vector<std::string>& enable_graphs) {
+    return ModelInitializeEx(model_name, "", model_path, backend_lib_path, system_lib_path, lora_adapters, async, input_data_type, output_data_type, deviceID, coreIdsStr, enable_graphs);
 }
 
 bool LibAppBuilder::ModelInference(std::string model_name, std::string proc_name, std::string share_memory_name,

--- a/src/LibAppBuilder.cpp
+++ b/src/LibAppBuilder.cpp
@@ -832,79 +832,79 @@ bool LibAppBuilder::DeleteShareMemory(std::string share_memory_name) {
 }
 
 // issue#24
-std::vector<std::vector<size_t>> LibAppBuilder::getOutputShapes(std::string model_name){
+std::vector<std::vector<size_t>> LibAppBuilder::getOutputShapes(std::string model_name, size_t graphIdx){
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4: guard against released/missing context.
         QNN_WARN("getOutputShapes: model not found or released: %s\n", model_name.c_str());
         return {};
     }
-    m_outputShapes = app->getOutputShapes();
+    m_outputShapes = app->getOutputShapes(graphIdx);
     putQnnApp(model_name, std::move(app));
     return m_outputShapes;
 };
 
-std::vector<std::vector<size_t>> LibAppBuilder::getInputShapes(std::string model_name){
+std::vector<std::vector<size_t>> LibAppBuilder::getInputShapes(std::string model_name, size_t graphIdx){
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getInputShapes: model not found or released: %s\n", model_name.c_str());
         return {};
     }
-    m_inputShapes = app->getInputShapes();
+    m_inputShapes = app->getInputShapes(graphIdx);
     putQnnApp(model_name, std::move(app));
     return m_inputShapes;
 };
 
-std::vector<std::string> LibAppBuilder::getInputDataType(std::string model_name){
+std::vector<std::string> LibAppBuilder::getInputDataType(std::string model_name, size_t graphIdx){
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getInputDataType: model not found or released: %s\n", model_name.c_str());
         return {};
     }
-    m_inputDataType = app->getInputDataType();
+    m_inputDataType = app->getInputDataType(graphIdx);
     putQnnApp(model_name, std::move(app));
     return m_inputDataType;
 };
 
-std::vector<std::string> LibAppBuilder::getOutputDataType(std::string model_name){
+std::vector<std::string> LibAppBuilder::getOutputDataType(std::string model_name, size_t graphIdx){
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getOutputDataType: model not found or released: %s\n", model_name.c_str());
         return {};
     }
-    m_outputDataType = app->getOutputDataType();
+    m_outputDataType = app->getOutputDataType(graphIdx);
     putQnnApp(model_name, std::move(app));
     return m_outputDataType;
 };
 
-std::string LibAppBuilder::getGraphName(std::string model_name){
+std::string LibAppBuilder::getGraphName(std::string model_name, size_t graphIdx){
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getGraphName: model not found or released: %s\n", model_name.c_str());
         return {};
     }
-    m_graphName = app->getGraphName();
+    m_graphName = app->getGraphName(graphIdx);
     putQnnApp(model_name, std::move(app));
     return m_graphName;
 };
 
-std::vector<std::string> LibAppBuilder::getInputName(std::string model_name){
+std::vector<std::string> LibAppBuilder::getInputName(std::string model_name, size_t graphIdx){
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getInputName: model not found or released: %s\n", model_name.c_str());
         return {};
     }
-    m_inputName = app->getInputName();
+    m_inputName = app->getInputName(graphIdx);
     putQnnApp(model_name, std::move(app));
     return m_inputName;
 };
 
-std::vector<std::string> LibAppBuilder::getOutputName(std::string model_name){
+std::vector<std::string> LibAppBuilder::getOutputName(std::string model_name, size_t graphIdx){
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getOutputName: model not found or released: %s\n", model_name.c_str());
         return {};
     }
-    m_outputName = app->getOutputName();
+    m_outputName = app->getOutputName(graphIdx);
     putQnnApp(model_name, std::move(app));
     return m_outputName;
 };

--- a/src/LibAppBuilder.hpp
+++ b/src/LibAppBuilder.hpp
@@ -96,13 +96,13 @@ public:
     bool CreateShareMemory(std::string share_memory_name, size_t share_memory_size);
     bool DeleteShareMemory(std::string share_memory_name);
 
-    std::vector<std::vector<size_t>> getInputShapes(std::string model_name);
-    std::vector<std::string> getInputDataType(std::string model_name);
-    std::vector<std::string> getOutputDataType(std::string model_name);
-    std::vector<std::vector<size_t>> getOutputShapes(std::string model_name);
-    std::string getGraphName(std::string model_name);
-    std::vector<std::string> getInputName(std::string model_name);
-    std::vector<std::string> getOutputName(std::string model_name);
+    std::vector<std::vector<size_t>> getInputShapes(std::string model_name, size_t graphIdx = 0);
+    std::vector<std::string> getInputDataType(std::string model_name, size_t graphIdx = 0);
+    std::vector<std::string> getOutputDataType(std::string model_name, size_t graphIdx = 0);
+    std::vector<std::vector<size_t>> getOutputShapes(std::string model_name, size_t graphIdx = 0);
+    std::string getGraphName(std::string model_name, size_t graphIdx = 0);
+    std::vector<std::string> getInputName(std::string model_name, size_t graphIdx = 0);
+    std::vector<std::string> getOutputName(std::string model_name, size_t graphIdx = 0);
 
     std::vector<std::vector<size_t>> getInputShapes(std::string model_name, std::string proc_name);
     std::vector<std::string> getInputDataType(std::string model_name, std::string proc_name);

--- a/src/LibAppBuilder.hpp
+++ b/src/LibAppBuilder.hpp
@@ -56,7 +56,7 @@ class LIBAPPBUILDER_API LibAppBuilder
 public:
     bool ModelInitialize(const std::string& model_name, const std::string& model_path,
                                const std::string& backend_lib_path, const std::string& system_lib_path,
-                               bool async = false, const std::string& input_data_type="float", const std::string& output_data_type="float", uint32_t deviceID=0, std::string coreIdsStr="");
+                               bool async = false, const std::string& input_data_type="float", const std::string& output_data_type="float", uint32_t deviceID=0, std::string coreIdsStr="", const std::vector<std::string>& enable_graphs={});
     bool ModelInitialize(const std::string& model_name, const std::string& proc_name, const std::string& model_path,
                                const std::string& backend_lib_path, const std::string& system_lib_path,
                                bool async = false, const std::string& input_data_type="float", const std::string& output_data_type="float", uint32_t deviceID=0, std::string coreIdsStr="");
@@ -64,7 +64,7 @@ public:
     bool ModelInitialize(const std::string& model_name, const std::string& model_path,
                          const std::string& backend_lib_path, const std::string& system_lib_path,
                          std::vector<LoraAdapter>& lora_adapters,
-                         bool async = false, const std::string& input_data_type="float", const std::string& output_data_type="float", uint32_t deviceID=0, std::string coreIdsStr="");
+                         bool async = false, const std::string& input_data_type="float", const std::string& output_data_type="float", uint32_t deviceID=0, std::string coreIdsStr="", const std::vector<std::string>& enable_graphs={});
 
     bool ModelInference(std::string model_name, std::vector<uint8_t*>& inputBuffers, 
                         std::vector<uint8_t*>& outputBuffers, std::vector<size_t>& outputSize,

--- a/src/QnnInferenceEngine.cpp
+++ b/src/QnnInferenceEngine.cpp
@@ -1650,117 +1650,185 @@ std::string dataTypeToString(Qnn_DataType_t dtype) {
     }
 }
 
-std::vector<std::vector<size_t>> qnn_app::QnnInferenceEngine::getInputShapes(){
-	if(m_inputShapes.empty()){
- 		size_t graphIdx = 0;
- 		auto graphInfo = (*m_graphsInfo)[graphIdx];
- 		Qnn_Tensor_t* inputs  = m_inputTensors[graphIdx];
-		for (size_t inputIdx = 0; inputIdx < graphInfo.numInputTensors; inputIdx++) {
-			if (QNN_TENSOR_GET_DIMENSIONS(inputs[inputIdx]) == nullptr || QNN_TENSOR_GET_RANK(inputs[inputIdx]) == 0) {
-				//printf("[ERROR] input tensor %zu has nullptr dimensions or rank == 0\n", inputIdx);
-				continue;
-			}
-			std::vector<size_t> dims;
-			m_ioTensor.fillDims(dims, QNN_TENSOR_GET_DIMENSIONS(inputs[inputIdx]), QNN_TENSOR_GET_RANK(inputs[inputIdx]));
-			m_inputShapes.push_back(dims);
-		}
-	}
-#ifdef DEBUG_INFERENCE
-  printf("[DEBUG]m_inputShapes:");
-  printArrayOfVector(m_inputShapes);
-#endif  
-  return m_inputShapes;
-}
+std::vector<std::vector<size_t>> qnn_app::QnnInferenceEngine::getInputShapes(size_t graphIdx){
+  if (nullptr == m_graphsInfo || graphIdx >= m_graphsCount) {
+    QNN_ERROR("getInputShapes: invalid graphIdx: %zu, graphsCount: %zu", graphIdx, m_graphsCount);
+    return {};
+  }
+  auto it = m_inputShapes.find(graphIdx);
+  if (it != m_inputShapes.end()) {
+    return it->second;
+  }
 
-std::string qnn_app::QnnInferenceEngine::getGraphName(){
-	if(m_graphName.empty()){
-		auto graphInfo = (*m_graphsInfo)[0/*graphIdx*/];
-		m_graphName  = graphInfo.graphName;
-	}
-    return m_graphName;
-}
-
-std::vector<std::string> qnn_app::QnnInferenceEngine::getInputName(){
-	if(m_inputName.empty()){
- 		size_t graphIdx = 0;
- 		auto graphInfo = (*m_graphsInfo)[graphIdx];
- 		Qnn_Tensor_t* inputs  = m_inputTensors[graphIdx];
- 		for (size_t inputIdx = 0; inputIdx < graphInfo.numInputTensors; inputIdx++) {
-			std::string inputName = QNN_TENSOR_GET_NAME(inputs[inputIdx]);
-			m_inputName.push_back(inputName);
-		}
+  auto graphInfo = (*m_graphsInfo)[graphIdx];
+  Qnn_Tensor_t* inputs = m_inputTensors[graphIdx];
+  if (nullptr == inputs) { return {}; }
+  std::vector<std::vector<size_t>> shapes;
+  for (size_t inputIdx = 0; inputIdx < graphInfo.numInputTensors; inputIdx++) {
+    if (QNN_TENSOR_GET_DIMENSIONS(inputs[inputIdx]) == nullptr ||
+        QNN_TENSOR_GET_RANK(inputs[inputIdx]) == 0) {
+        continue;
     }
-	return m_inputName;
-}
-
-
-std::vector<std::string> qnn_app::QnnInferenceEngine::getOutputName(){
-	if(m_outputName.empty()){
- 		size_t graphIdx = 0;
- 		auto graphInfo = (*m_graphsInfo)[graphIdx];
- 		Qnn_Tensor_t* outputs  = m_outputTensors[graphIdx];
-		for (size_t outputIdx = 0; outputIdx < graphInfo.numOutputTensors; outputIdx++) {
-			std::string outputName = QNN_TENSOR_GET_NAME(outputs[outputIdx]);
-			m_outputName.push_back(outputName);
-		}
-	}
-	return m_outputName;
-}
-
-std::vector<std::string> qnn_app::QnnInferenceEngine::getInputDataType(){
-	if(m_inputDataType_s.empty()){
- 		size_t graphIdx = 0;
- 		auto graphInfo = (*m_graphsInfo)[graphIdx];
- 		Qnn_Tensor_t* inputs  = m_inputTensors[graphIdx];
-		for (size_t inputIdx = 0; inputIdx < graphInfo.numInputTensors; inputIdx++) {
-			Qnn_DataType_t dims_inputDataType = QNN_TENSOR_GET_DATA_TYPE(inputs[inputIdx]);
-			m_inputDataType_s.push_back(dataTypeToString(dims_inputDataType));
-		}
-	}
+    std::vector<size_t> dims;
+    m_ioTensor.fillDims(dims, QNN_TENSOR_GET_DIMENSIONS(inputs[inputIdx]),
+                        QNN_TENSOR_GET_RANK(inputs[inputIdx]));
+    shapes.push_back(dims);
+  }
+  m_inputShapes[graphIdx] = shapes;
 #ifdef DEBUG_INFERENCE
-    printf("[DEBUG]m_inputDataType_s:");
-    printDataTypes(m_inputDataType_s);
-#endif 
-    return m_inputDataType_s;  
-}
-
-std::vector<std::vector<size_t>> qnn_app::QnnInferenceEngine::getOutputShapes(){
-	if(m_outputShapes.empty()){
- 		size_t graphIdx = 0;
- 		auto graphInfo = (*m_graphsInfo)[graphIdx];
- 		Qnn_Tensor_t* outputs  = m_outputTensors[graphIdx];
-		for (size_t outputIdx = 0; outputIdx < graphInfo.numOutputTensors; outputIdx++) {
-			if (QNN_TENSOR_GET_DIMENSIONS(outputs[outputIdx]) == nullptr || QNN_TENSOR_GET_RANK(outputs[outputIdx]) == 0) {
-				//printf("[ERROR] Output tensor %zu has nullptr dimensions or rank == 0\n", outputIdx);
-				continue;
-			}
-			std::vector<size_t> dims;
-			m_ioTensor.fillDims(dims, QNN_TENSOR_GET_DIMENSIONS(outputs[outputIdx]), QNN_TENSOR_GET_RANK(outputs[outputIdx]));
-			m_outputShapes.push_back(dims);
-		}
-	}
-#ifdef DEBUG_INFERENCE
-  printf("[DEBUG]m_outputShapes:");
-  printArrayOfVector(m_outputShapes);
+  printf("[DEBUG]m_inputShapes[%zu]:", graphIdx);
+  printArrayOfVector(shapes);
 #endif
-  return m_outputShapes;
+  return shapes;
 }
 
-std::vector<std::string> qnn_app::QnnInferenceEngine::getOutputDataType(){
-	if(m_outputDataType_s.empty()){
- 		size_t graphIdx = 0;
- 		auto graphInfo = (*m_graphsInfo)[graphIdx];
- 		Qnn_Tensor_t* outputs  = m_outputTensors[graphIdx];
-		for (size_t outputIdx = 0; outputIdx < graphInfo.numOutputTensors; outputIdx++) {
-			Qnn_DataType_t dims_outputDataType = QNN_TENSOR_GET_DATA_TYPE(outputs[outputIdx]);
-			m_outputDataType_s.push_back(dataTypeToString(dims_outputDataType));
-		}
-	}
+std::string qnn_app::QnnInferenceEngine::getGraphName(size_t graphIdx){
+  if (nullptr == m_graphsInfo || graphIdx >= m_graphsCount) {
+    QNN_ERROR("getGraphName: invalid graphIdx: %zu, graphsCount: %zu", graphIdx, m_graphsCount);
+    return {};
+  }
+  auto it = m_graphName.find(graphIdx);
+  if (it != m_graphName.end()) {
+    return it->second;
+  }
+  const char* name = (*m_graphsInfo)[graphIdx].graphName;
+  std::string result = (nullptr != name) ? name : "";
+  m_graphName[graphIdx] = result;
+  return result;
+}
+
+std::vector<std::string> qnn_app::QnnInferenceEngine::getInputName(size_t graphIdx){
+  if (nullptr == m_graphsInfo || graphIdx >= m_graphsCount) {
+    QNN_ERROR("getInputName: invalid graphIdx: %zu, graphsCount: %zu", graphIdx, m_graphsCount);
+    return {};
+  }
+  auto it = m_inputName.find(graphIdx);
+  if (it != m_inputName.end()) {
+    return it->second;
+  }
+
+  auto graphInfo = (*m_graphsInfo)[graphIdx];
+  Qnn_Tensor_t* inputs = m_inputTensors[graphIdx];
+  if (nullptr == inputs) { return {}; }
+  std::vector<std::string> names;
+  for (size_t inputIdx = 0; inputIdx < graphInfo.numInputTensors; inputIdx++) {
+    names.push_back(QNN_TENSOR_GET_NAME(inputs[inputIdx]));
+  }
+  m_inputName[graphIdx] = names;
+  return names;
+}
+
+
+std::vector<std::string> qnn_app::QnnInferenceEngine::getOutputName(size_t graphIdx){
+  if (nullptr == m_graphsInfo || graphIdx >= m_graphsCount) {
+    QNN_ERROR("getOutputName: invalid graphIdx: %zu, graphsCount: %zu", graphIdx, m_graphsCount);
+    return {};
+  }
+  auto it = m_outputName.find(graphIdx);
+  if (it != m_outputName.end()) {
+    return it->second;
+  }
+
+  auto graphInfo = (*m_graphsInfo)[graphIdx];
+  Qnn_Tensor_t* outputs  = m_outputTensors[graphIdx];
+  if (nullptr == outputs) { return {}; }  // no tensors set up for this graph
+  std::vector<std::string> names;
+  for (size_t outputIdx = 0; outputIdx < graphInfo.numOutputTensors; outputIdx++) {
+    names.push_back(QNN_TENSOR_GET_NAME(outputs[outputIdx]));
+  }
+  m_outputName[graphIdx] = names;
+  return names;
+}
+
+std::vector<std::string> qnn_app::QnnInferenceEngine::getInputDataType(size_t graphIdx){
+  if (nullptr == m_graphsInfo || graphIdx >= m_graphsCount) {
+    QNN_ERROR("getInputDataType: invalid graphIdx: %zu, graphsCount: %zu", graphIdx, m_graphsCount);
+    return {};
+  }
+  auto it = m_inputDataType_s.find(graphIdx);
+  if (it != m_inputDataType_s.end()) {
+    return it->second;
+  }
+
+  auto graphInfo = (*m_graphsInfo)[graphIdx];
+  Qnn_Tensor_t* inputs  = m_inputTensors[graphIdx];
+  if (nullptr == inputs) { return {}; }  // no tensors set up for this graph
+  std::vector<std::string> dtypes;
+  for (size_t inputIdx = 0; inputIdx < graphInfo.numInputTensors; inputIdx++) {
+    dtypes.push_back(dataTypeToString(QNN_TENSOR_GET_DATA_TYPE(inputs[inputIdx])));
+  }
+  m_inputDataType_s[graphIdx] = dtypes;
 #ifdef DEBUG_INFERENCE
-	printf("[DEBUG]m_outputDataType_s:");
-	printDataTypes(m_outputDataType_s);
+  printf("[DEBUG]m_inputDataType_s[%zu]:", graphIdx);
+  printDataTypes(dtypes);
 #endif
-	return m_outputDataType_s;
+  return dtypes;
+}
+
+std::vector<std::vector<size_t>> qnn_app::QnnInferenceEngine::getOutputShapes(size_t graphIdx){
+  if (nullptr == m_graphsInfo || graphIdx >= m_graphsCount) {
+    QNN_ERROR("getOutputShapes: invalid graphIdx: %zu, graphsCount: %zu", graphIdx, m_graphsCount);
+    return {};
+  }
+  auto it = m_outputShapes.find(graphIdx);
+  if (it != m_outputShapes.end()) {
+    return it->second;
+  }
+
+  std::vector<std::vector<size_t>> shapes;
+  auto graphInfo = (*m_graphsInfo)[graphIdx];
+  Qnn_Tensor_t* outputs = m_outputTensors[graphIdx];
+  if (nullptr == outputs) {
+    QNN_ERROR("getOutputShapes: no output tensors for graph %zu", graphIdx);
+    return {};
+  }
+  for (size_t outputIdx = 0; outputIdx < graphInfo.numOutputTensors; outputIdx++) {
+    if (QNN_TENSOR_GET_DIMENSIONS(outputs[outputIdx]) == nullptr ||
+        QNN_TENSOR_GET_RANK(outputs[outputIdx]) == 0) {
+        continue;
+    }
+    std::vector<size_t> dims;
+    m_ioTensor.fillDims(dims, QNN_TENSOR_GET_DIMENSIONS(outputs[outputIdx]),
+                        QNN_TENSOR_GET_RANK(outputs[outputIdx]));
+    shapes.push_back(dims);
+  }
+  m_outputShapes[graphIdx] = shapes;
+
+#ifdef DEBUG_INFERENCE
+  printf("[DEBUG]m_outputShapes[%zu]:", graphIdx);
+  printArrayOfVector(shapes);
+#endif
+  return shapes;
+}
+
+std::vector<std::string> qnn_app::QnnInferenceEngine::getOutputDataType(size_t graphIdx){
+  if (nullptr == m_graphsInfo || graphIdx >= m_graphsCount) {
+    QNN_ERROR("getOutputDataType: invalid graphIdx: %zu, graphsCount: %zu", graphIdx, m_graphsCount);
+    return {};
+  }
+  auto it = m_outputDataType_s.find(graphIdx);
+  if (it != m_outputDataType_s.end()) {
+    return it->second;
+  }
+
+  std::vector<std::string> dtypes;
+  auto graphInfo = (*m_graphsInfo)[graphIdx];
+  Qnn_Tensor_t* outputs = m_outputTensors[graphIdx];
+  if (nullptr == outputs) {
+    QNN_ERROR("getOutputDataType: no output tensors for graph %zu", graphIdx);
+    return {};
+  }
+  for (size_t outputIdx = 0; outputIdx < graphInfo.numOutputTensors; outputIdx++) {
+    Qnn_DataType_t dims_outputDataType = QNN_TENSOR_GET_DATA_TYPE(outputs[outputIdx]);
+    dtypes.push_back(dataTypeToString(dims_outputDataType));
+  }
+  m_outputDataType_s[graphIdx] = dtypes;
+
+#ifdef DEBUG_INFERENCE
+  printf("[DEBUG]m_outputDataType_s[%zu]:", graphIdx);
+  printDataTypes(dtypes);
+#endif
+  return dtypes;
 }
 
 qnn_app::StatusCode qnn_app::QnnInferenceEngine::executeGraphsBuffers(std::vector<uint8_t*>& inputBuffers, 

--- a/src/QnnInferenceEngine.cpp
+++ b/src/QnnInferenceEngine.cpp
@@ -446,6 +446,10 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::freeContext() {
   }
   free(m_graphsInfo);
   m_graphsInfo = nullptr;
+  m_contextConfig = nullptr;
+  m_contextConfigPtrs.clear();
+  m_enabledGraphCstr.clear();
+  m_enabledGraphIndex.clear();
 
   if (QNN_CONTEXT_NO_ERROR !=
       m_qnnFunctionPointers.qnnInterface.contextFree(m_context, m_profileBackendHandle)) {
@@ -940,6 +944,12 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::createFromBinary() {
   }
 
   if (StatusCode::SUCCESS == returnStatus &&
+      StatusCode::SUCCESS != setupContextConfigs()) {
+    QNN_ERROR("Failed to set up context configs.");
+    returnStatus = StatusCode::FAILURE;
+  }
+
+  if (StatusCode::SUCCESS == returnStatus &&
       nullptr == m_qnnFunctionPointers.qnnInterface.contextCreateFromBinary) {
     QNN_ERROR("contextCreateFromBinaryFnHandle is nullptr.");
     returnStatus = StatusCode::FAILURE;
@@ -1155,6 +1165,58 @@ uint64_t qnn_app::QnnInferenceEngine::getProfilingEvent(uint32_t eventType) {
     }
   }
   return 0;
+}
+
+qnn_app::StatusCode qnn_app::QnnInferenceEngine::setupContextConfigs() {
+  m_contextConfig = nullptr;
+  m_enabledGraphIndex.clear();
+  m_enabledGraphCstr.clear();
+  m_contextConfigPtrs.clear();
+
+  // enable all graphs
+  if (m_enabledGraphs.empty()) {
+    return StatusCode::SUCCESS;
+  }
+  // Set up enabled graphs config.
+  if (m_qnnFunctionPointers.qnnInterface.propertyHasCapability(
+          QNN_PROPERTY_CONTEXT_SUPPORT_CONFIG_ENABLE_GRAPHS) != QNN_PROPERTY_SUPPORTED) {
+    QNN_WARN("Backend does not support graph selection, Disabling this feature");
+    m_enabledGraphs.clear();
+    return StatusCode::SUCCESS;
+  }
+
+
+  // Keep track of which indices are enabled. (-1 means not enabled)
+  // Set enabled graphs to the corresponding index in the enabled graph arg so we know the
+  // corresponding input list.
+  m_enabledGraphIndex = std::vector<int>(m_graphsCount, -1);
+  m_enabledGraphCstr  = std::vector<const char*>(m_enabledGraphs.size() + 1, nullptr);
+  for (size_t enabledIter = 0; enabledIter < m_enabledGraphs.size(); ++enabledIter) {
+    // Check to make sure that the graph exists in the context.
+    bool found = false;
+    for (size_t graphNameIter = 0; graphNameIter < m_graphsCount; ++graphNameIter) {
+      if (nullptr != (*m_graphsInfo)[graphNameIter].graphName &&
+          m_enabledGraphs[enabledIter] == (*m_graphsInfo)[graphNameIter].graphName) {
+        m_enabledGraphCstr[enabledIter]    = (*m_graphsInfo)[graphNameIter].graphName;
+        m_enabledGraphIndex[graphNameIter] = enabledIter;
+        found                              = true;
+        break;
+      }
+    }
+    if (!found) {
+      QNN_ERROR("Enabled graph %s not found in context", m_enabledGraphs[enabledIter].c_str());
+      return StatusCode::FAILURE;
+    }
+  }
+  m_enabledGraphsCfg.option       = QnnContext_ConfigOption_t::QNN_CONTEXT_CONFIG_ENABLE_GRAPHS;
+  m_enabledGraphsCfg.enableGraphs = m_enabledGraphCstr.data();
+  m_contextConfigPtrs.push_back(&m_enabledGraphsCfg);
+  m_contextConfigPtrs.push_back(nullptr);   // QNN expects a null-terminated array
+  m_contextConfig = m_contextConfigPtrs.data();
+
+  QNN_INFO("Creating %d of %d graphs", (int)m_enabledGraphs.size(), (int)m_graphsCount);
+
+  return StatusCode::SUCCESS;
 }
 
 qnn_app::StatusCode qnn_app::QnnInferenceEngine::verifyFailReturnStatus(Qnn_ErrorHandle_t errCode) {
@@ -1583,6 +1645,12 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::setupInputAndOutputTensors()
   auto returnStatus = qnn::tools::iotensor::StatusCode::SUCCESS;
 
   for (size_t graphIdx = 0; graphIdx < m_graphsCount; graphIdx++) {
+    // push nullptr so both tensors stay indexed by graphIdx
+    if(!m_enabledGraphIndex.empty() && m_enabledGraphIndex[graphIdx] < 0){
+      m_inputTensors.push_back(nullptr);
+      m_outputTensors.push_back(nullptr);
+      continue;
+    }
     auto& graphInfo = (*m_graphsInfo)[graphIdx];
     Qnn_Tensor_t* inputs  = nullptr;
     Qnn_Tensor_t* outputs = nullptr;

--- a/src/QnnInferenceEngine.hpp
+++ b/src/QnnInferenceEngine.hpp
@@ -170,6 +170,7 @@ class QnnInferenceEngine {
 
   void setIsGpu(bool isGpu) { m_isGpu = isGpu; }
   void setIsCpu(bool isCpu) { m_runInCpu = isCpu; }
+  void setEnabledGraphs(const std::vector<std::string>& graphNames) { m_enabledGraphs = graphNames; }
 
   StatusCode initializePerformance();
   StatusCode destroyPerformance();
@@ -186,6 +187,7 @@ class QnnInferenceEngine {
   StatusCode composeGraphsFromDlc();
   StatusCode getDevicePlatformInfo(const QnnDevice_PlatformInfo_t *&platformInfoPtr);
   StatusCode setupDeviceConfig(QnnDevice_Config_t* devConfigPtr, MultiCoreDeviceConfig_t* multicoreConfigPtr);
+  StatusCode setupContextConfigs();
   static const std::string s_defaultOutputPath;
 
   QnnFunctionPointers m_qnnFunctionPointers;
@@ -202,6 +204,12 @@ class QnnInferenceEngine {
   QnnBackend_Config_t **m_backendConfig = nullptr;
   Qnn_ContextHandle_t m_context         = nullptr;
   QnnContext_Config_t **m_contextConfig = nullptr;
+  std::vector<std::string> m_enabledGraphs;
+  std::vector<int> m_enabledGraphIndex;
+  // Memory needs to be maintained.
+  std::vector<const char *> m_enabledGraphCstr;
+  QnnContext_Config_t m_enabledGraphsCfg;
+  std::vector<QnnContext_Config_t *> m_contextConfigPtrs;
   bool m_debug;
   iotensor::OutputDataType m_outputDataType;
   iotensor::InputDataType m_inputDataType;

--- a/src/QnnInferenceEngine.hpp
+++ b/src/QnnInferenceEngine.hpp
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <queue>
+#include <map>
 
 #include "IOTensor.hpp"
 #include "DynamicLoadUtil.hpp"
@@ -153,13 +154,13 @@ class QnnInferenceEngine {
                                   std::vector<uint8_t*>& outputBuffers, std::vector<size_t>& outputSize,
                                   std::string perfProfile, size_t graphIndex = 0, size_t share_memory_size = 0);
   // issue#24
-  std::vector<std::vector<size_t>> getInputShapes();
-  std::vector<std::string> getInputDataType();
-  std::vector<std::vector<size_t>> getOutputShapes();
-  std::vector<std::string> getOutputDataType();
-  std::string getGraphName();
-  std::vector<std::string> getInputName();
-  std::vector<std::string> getOutputName();
+  std::vector<std::vector<size_t>> getInputShapes(size_t graphIdx = 0);
+  std::vector<std::string> getInputDataType(size_t graphIdx = 0);
+  std::vector<std::vector<size_t>> getOutputShapes(size_t graphIdx = 0);
+  std::vector<std::string> getOutputDataType(size_t graphIdx = 0);
+  std::string getGraphName(size_t graphIdx = 0);
+  std::vector<std::string> getInputName(size_t graphIdx = 0);
+  std::vector<std::string> getOutputName(size_t graphIdx = 0);
   uint64_t getProfilingEvent(uint32_t eventType);
   qnn_wrapper_api::GraphInfo_t **m_graphsInfo;
   uint32_t m_graphsCount;
@@ -230,13 +231,13 @@ class QnnInferenceEngine {
   bool m_isGpu = false;
 
   // issue#24
-  std::vector<std::vector<size_t>> m_inputShapes;
-  std::vector<std::string> m_inputDataType_s;
-  std::vector<std::vector<size_t>> m_outputShapes;
-  std::vector<std::string> m_outputDataType_s;
-  std::string m_graphName;
-  std::vector<std::string>  m_inputName;
-  std::vector<std::string>  m_outputName;
+  std::map<size_t, std::vector<std::vector<size_t>>> m_inputShapes;
+  std::map<size_t, std::vector<std::string>> m_inputDataType_s;
+  std::map<size_t, std::vector<std::vector<size_t>>> m_outputShapes;
+  std::map<size_t, std::vector<std::string>> m_outputDataType_s;
+  std::map<size_t, std::string> m_graphName;
+  std::map<size_t,  std::vector<std::string>> m_inputName;
+  std::map<size_t, std::vector<std::string>> m_outputName;
 
   std::string m_dlcPath;
   QnnSystemDlc_Handle_t m_dlcHandle = nullptr;


### PR DESCRIPTION
## Summary

  Add support for running a single weight-shared `.serialized.bin` that packs
  multiple graphs (e.g. one graph per resolution, sharing weights). Two pieces:

  1. **`enable_graphs`** — create only the graph(s) you name, instead of all of them.
  2. **per-graph metadata getters (`graphIdx`)** — query the shapes/dtypes/names of
     a specific graph, fixing getters that previously always returned graph 0.

  ## enable_graphs

  AppBuilder allocates every graph's input/output tensors at load time.
  For a weight-shared binary that means all graphs' tensors are resident at once,
  which can exceed a single HTP
  protection domain — loading fails with `Failed to find available PD ... err 1002`.

  `enable_graphs` passes a `QNN_CONTEXT_CONFIG_ENABLE_GRAPHS` context config so
  only the named graphs are created; unselected graphs get `nullptr` tensor
  placeholders (indices stay aligned so `graphIndex` remains the graph's absolute
  position in the binary). Not passing `enable_graphs` preserves the old
  "create all graphs" behaviour.

  Exposed as a flat `enable_graphs=None` argument on `QNNContext` / `QNNLoraContext`.
  The out-of-process `proc_name` path is intentionally not supported (it can't
  carry the list over the IPC protocol).

  ## Getter fix (graphIdx)

  Getter added `graphIndex` on the execute path but the
  metadata getters still hardcoded graph 0, so with graphs of differing I/O shapes
  the output reshaping used the wrong shape. All seven getters
  (`getInput/OutputShapes`, `getInput/OutputDataType`, `getInput/OutputName`,
  `getGraphName`) now take an optional `graphIdx` (default `0`) threaded through
  every layer (engine → LibAppBuilder → pybind → Python), with per-graph results
  cached in `std::map<size_t, T>`. The default keeps single-graph call sites
  unchanged.

  ## Testing

  - Regression: single-graph samples load and run unchanged.
  - Weight-shared binary: verified `Creating 1 of N graphs`, per-graph
    `getOutputShapes(graphIdx)` returns the selected graph's real shape, and the
    end-to-end pipeline produces correct output at multiple resolutions.
  - Negative: an `enable_graphs` name not present in the binary fails with a clear
    "Enabled graph ... not found in context" error.