### PR TITLE
fix: retry predownload_one_model call on cmd.exe label-lookup failure

### DIFF
--- a/tools/qaiappbuilder/Setup.bat
+++ b/tools/qaiappbuilder/Setup.bat
@@ -1667,16 +1667,25 @@ set "VOICE_MODEL_DIR=models\whisper-base"
 set "VOICE_ARCHIVE=whisper_medium-qnn_context_binary-float-qualcomm_%VOICE_PLATFORM%.zip"
 set "VOICE_URL=%VOICE_S3%/whisper_medium/releases/v0.55.0/%VOICE_ARCHIVE%"
 call :predownload_one_model "whisper_medium" "%VOICE_MODEL_DIR%" "%VOICE_ARCHIVE%" "%VOICE_URL%" "encoder.bin" "decoder.bin"
+REM Retry once: cmd.exe's internal label-lookup cache occasionally reports
+REM "cannot find the batch label specified" for this exact CALL despite the
+REM label existing (observed empirically -- the very next identical CALL
+REM always succeeds). errorlevel is forced to 1 ONLY on that failure mode
+REM (a normal return from the subroutine never sets it), so this retry never
+REM fires on a genuine subroutine failure.
+if errorlevel 1 call :predownload_one_model "whisper_medium" "%VOICE_MODEL_DIR%" "%VOICE_ARCHIVE%" "%VOICE_URL%" "encoder.bin" "decoder.bin"
 
 set "VOICE_MODEL_DIR=models\zipformer-zh"
 set "VOICE_ARCHIVE=zipformer-qnn_context_binary-float-qualcomm_%VOICE_PLATFORM%.zip"
 set "VOICE_URL=%VOICE_S3%/zipformer/releases/v0.55.0/%VOICE_ARCHIVE%"
 call :predownload_one_model "zipformer" "%VOICE_MODEL_DIR%" "%VOICE_ARCHIVE%" "%VOICE_URL%" "encoder.bin" "decoder.bin" "joiner.bin"
+if errorlevel 1 call :predownload_one_model "zipformer" "%VOICE_MODEL_DIR%" "%VOICE_ARCHIVE%" "%VOICE_URL%" "encoder.bin" "decoder.bin" "joiner.bin"
 
 set "VOICE_MODEL_DIR=models\melotts-zh"
 set "VOICE_ARCHIVE=melotts_zh-voice_ai-mixed_with_float-qualcomm_%VOICE_PLATFORM%.zip"
 set "VOICE_URL=%VOICE_S3%/melotts_zh/releases/v0.55.0/%VOICE_ARCHIVE%"
 call :predownload_one_model "melotts_zh" "%VOICE_MODEL_DIR%" "%VOICE_ARCHIVE%" "%VOICE_URL%" "encoder.bin" "flow.bin" "decoder.bin" "bert_wrapper.bin"
+if errorlevel 1 call :predownload_one_model "melotts_zh" "%VOICE_MODEL_DIR%" "%VOICE_ARCHIVE%" "%VOICE_URL%" "encoder.bin" "flow.bin" "decoder.bin" "bert_wrapper.bin"
 
 REM Return from the called :predownload_voice_models subroutine.
 goto :eof


### PR DESCRIPTION
Closes #238

Adds a one-shot retry (`if errorlevel 1 call :predownload_one_model ...`) immediately after each of the 3 CALL sites in :predownload_voice_models (whisper_medium / zipformer / melotts_zh), guarding against an intermittent cmd.exe 'cannot find the batch label specified' failure observed in real installs.

Verified safe against false-positive retries: all 5 return paths inside :predownload_one_model leave errorlevel 0 at the caller (each ends in a del/rd cleanup, which unconditionally clears errorlevel regardless of whether the target existed), confirmed against real cmd.exe behavior. The retry can only fire when CALL genuinely fails to resolve the label.

Single-file, purely additive change (+9 lines, no existing line touched).