### PR TITLE
fix: fork()-safety guards to prevent child process from corrupting parent's QNN/FastRPC state

### DIFF
--- a/script/qai_appbuilder/qnncontext.py
+++ b/script/qai_appbuilder/qnncontext.py
@@ -691,6 +691,9 @@ class _QNNContextBase:
         # gets its own independent flag and there is no risk of the class-level
         # default being read before the first write.
         self._released = False
+        # issue#97: record the PID that created this context so we can detect
+        # inherited instances in fork()ed children and skip C++ teardown.
+        self._creator_pid = os.getpid()
 
     def _validate_model_path(self):
         if self.model_path == "None":
@@ -707,6 +710,15 @@ class _QNNContextBase:
 
     def _ensure_live(self, op: str):
         """Raise if the context has already been released (issue#109, issue#4)."""
+        # issue#97: detect inherited context in a fork()ed child.
+        if getattr(self, "_creator_pid", None) is not None and os.getpid() != self._creator_pid:
+            raise RuntimeError(
+                f"Cannot perform '{op}': this QNN context was created in process "
+                f"{self._creator_pid} and inherited via fork() into child process "
+                f"{os.getpid()}. The inherited QNN/FastRPC state cannot be used "
+                f"safely. Use multiprocessing with the 'spawn' start method, or "
+                f"create the child process before initializing QNN."
+            )
         if getattr(self, "_released", False) or getattr(self, "m_context", None) is None:
             raise RuntimeError(
                 f"Cannot perform '{op}': context "
@@ -768,6 +780,20 @@ class _QNNContextBase:
         if getattr(self, "_released", False):
             return
         self._released = True
+        # issue#97: in a fork()ed child, do NOT call del on the inherited C++
+        # context — the pybind destructor would trigger QNN teardown APIs
+        # (contextFree, backendFree) via inherited FastRPC fds, corrupting the
+        # parent's DSP session. Simply drop the Python reference; the C++ side
+        # has its own PID guard in ~QnnInferenceEngine() as a safety net. The
+        # leaked C++ object is reclaimed by the OS when the child exits.
+        creator_pid = getattr(self, "_creator_pid", None)
+        if creator_pid is not None and os.getpid() != creator_pid:
+            self.m_context = None
+            try:
+                _unregister_context(self)
+            except Exception:
+                pass
+            return
         m_context = getattr(self, "m_context", None)
         if m_context is not None:
             self.m_context = None

--- a/src/LibAppBuilder.cpp
+++ b/src/LibAppBuilder.cpp
@@ -39,6 +39,21 @@
   #include <execution>
 #endif
 
+// ---------------------------------------------------------------------------
+// issue#97: fork()-safety — detect forked children and prevent them from
+// using or tearing down the parent's inherited QNN/FastRPC state.
+// ---------------------------------------------------------------------------
+#ifdef __linux__
+#include <unistd.h>
+// PID of the process that first initialized the QNN backend. A forked child
+// inherits this value; comparing it with getpid() detects the fork.
+static pid_t sg_qnnOwnerPid = -1;
+
+static bool isForkedChildWithInheritedQnnState() noexcept {
+    return sg_qnnOwnerPid > 0 && getpid() != sg_qnnOwnerPid;
+}
+#endif
+
 using namespace qnn;
 using namespace qnn::log;
 using namespace qnn::tools;
@@ -152,6 +167,13 @@ std::unique_ptr<qnn_app::QnnInferenceEngine> initQnnInferenceEngine(std::string 
 #endif
 
   sg_qnnInterface = qnnFunctionPointers.qnnInterface;
+
+#ifdef __linux__
+  // issue#97: record which process owns the backend state loaded above.
+  if (sg_qnnOwnerPid == -1) {
+      sg_qnnOwnerPid = getpid();
+  }
+#endif
   std::unique_ptr<qnn_app::QnnInferenceEngine> app(new qnn_app::QnnInferenceEngine(qnnFunctionPointers, "null", opPackagePaths, sg_backendHandle, "null",
                                                                              debug, parsedOutputDataType, parsedInputDataType, sg_parsedProfilingLevel,
                                                                              dumpOutputs, cachedBinaryPath2, saveBinaryName, lora_adapters, cachedBinaryPath2, multiCoreDeviceConfig));
@@ -234,6 +256,12 @@ bool SetLogLevel(int32_t log_level, const std::string log_path) {
 }
 
 bool SetPerfProfileGlobal(const std::string& perf_profile) {
+#ifdef __linux__
+    if (isForkedChildWithInheritedQnnState()) {
+        QNN_WARN("SetPerfProfileGlobal: skipping in fork()ed child (issue#97).\n");
+        return true;
+    }
+#endif
     // In cross-process mode the model lives in the Svc child process, so the
     // perf profile must be applied there. Forward to all Svc processes; if any
     // exist, that is authoritative and we return its result. With no Svc process
@@ -271,6 +299,12 @@ bool SetPerfProfileGlobal(const std::string& perf_profile) {
 }
 
 bool RelPerfProfileGlobal() {
+#ifdef __linux__
+    if (isForkedChildWithInheritedQnnState()) {
+        QNN_WARN("RelPerfProfileGlobal: skipping in fork()ed child (issue#97).\n");
+        return true;
+    }
+#endif
     // Mirror SetPerfProfileGlobal: forward to Svc processes in cross-process mode.
     if (!sg_proc_info_map.empty()) {
         return TalkToSvc_RelPerfProfileGlobal();
@@ -458,6 +492,19 @@ bool ModelInitializeEx(const std::string& model_name, const std::string& proc_na
                        bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID=0, std::string coreIdsStr="", const std::vector<std::string>& enable_graphs={}) {
   QNN_INFO("LibAppBuilder::ModelInitialize: %s \n", model_name.c_str());
 
+#ifdef __linux__
+  // issue#97: reject QNN operations in a fork()ed child that inherited the
+  // parent's backend state. The inherited QNN/FastRPC handles, device fds and
+  // library static state cannot be reused or rebuilt safely in the child.
+  if (isForkedChildWithInheritedQnnState()) {
+      QNN_ERROR("ModelInitializeEx: QNN was initialized before fork(). The inherited "
+                "QNN/FastRPC state cannot be used safely in this child process. "
+                "Use multiprocessing with the 'spawn' start method, or create "
+                "the child before initializing QNN.\n");
+      return false;
+  }
+#endif
+
   bool result = false;
 
   if(!proc_name.empty()) {
@@ -636,6 +683,14 @@ bool ModelInferenceEx(std::string model_name, std::string proc_name, std::string
 
     QNN_INFO("LibAppBuilder::ModelInference: %s \n", model_name.c_str());
 
+#ifdef __linux__
+    if (isForkedChildWithInheritedQnnState()) {
+        QNN_ERROR("ModelInferenceEx: cannot run inference in a fork()ed child "
+                  "with inherited QNN state (issue#97).\n");
+        return false;
+    }
+#endif
+
     if (!proc_name.empty()) {
         // If proc_name, run the model in that process.
         result = TalkToSvc_Inference(model_name, proc_name, share_memory_name, inputBuffers, inputSize, outputBuffers, outputSize, perfProfile, graphIndex);
@@ -667,6 +722,14 @@ bool ModelInferenceEx(std::string model_name, std::string proc_name, std::string
 
 bool ModelDestroyEx(std::string model_name, std::string proc_name) {
     QNN_INFO("LibAppBuilder::ModelDestroy: %s \n", model_name.c_str());
+
+#ifdef __linux__
+    if (isForkedChildWithInheritedQnnState()) {
+        QNN_WARN("ModelDestroyEx: skipping teardown in fork()ed child to protect "
+                 "the parent's QNN/FastRPC session (issue#97).\n");
+        return true;  // no-op success — resources leak intentionally
+    }
+#endif
 
     bool result = false;
 

--- a/src/QnnInferenceEngine.cpp
+++ b/src/QnnInferenceEngine.cpp
@@ -232,10 +232,24 @@ qnn_app::QnnInferenceEngine::QnnInferenceEngine(QnnFunctionPointers qnnFunctionP
       QNN_DEBUG("Run model on HTP.");
   }
 
+#ifdef __linux__
+  m_creatorPid = getpid();
+#endif
+
   return;
 }
 
 qnn_app::QnnInferenceEngine::~QnnInferenceEngine() {
+#ifdef __linux__
+  // issue#97: this instance was inherited from a fork()ed parent. Do NOT call
+  // any QNN teardown APIs (contextFree, backendFree, profileFree, logFree) —
+  // they would operate on the parent's DSP/FastRPC session via inherited fds,
+  // corrupting the parent's state. The leaked resources are reclaimed by the
+  // OS when this child process exits.
+  if (m_creatorPid > 0 && getpid() != m_creatorPid) {
+      return;
+  }
+#endif
   // Free DLC resources using utility function
   dlc_utils::freeDlcResources(m_qnnFunctionPointers.qnnSystemInterfaceHandle,
                               m_dlcHandle,

--- a/src/QnnInferenceEngine.hpp
+++ b/src/QnnInferenceEngine.hpp
@@ -21,6 +21,9 @@
 
 
 #include "QnnDevice.h"
+#ifdef __linux__
+#include <unistd.h>  // issue#97: pid_t for fork-safety guard
+#endif
 
 bool disableDcvs(QnnHtpDevice_PerfInfrastructure_t perfInfra);
 bool enableDcvs(QnnHtpDevice_PerfInfrastructure_t perfInfra);
@@ -254,6 +257,12 @@ class QnnInferenceEngine {
   std::vector<Qnn_Tensor_t*> m_inputTensors;
   std::vector<Qnn_Tensor_t*> m_outputTensors;
   MultiCoreDeviceConfig_t m_multiCoreDeviceConfig = {};
+
+#ifdef __linux__
+  // issue#97: PID of the process that created this engine instance. Used to
+  // detect inherited instances in fork()ed children and skip teardown.
+  pid_t m_creatorPid{-1};
+#endif
 };
 }  // namespace qnn_app
 }  // namespace tools


### PR DESCRIPTION
Closes #241
Relates to: #97, #109, #122

## Problem

On Linux, `multiprocessing` defaults to `fork()`. A child process inherits the parent's QNN backend handles, device handles, FastRPC fds, and library static state. If the child uses or tears down these inherited handles, it corrupts the parent's DSP session (`err 1002`).

## Approach

**Detect the fork, make inherited state inert.** Do not attempt to rebuild QNN in the forked child — ordinary `dlopen()` returns the already-loaded library (not a fresh instance), and the kernel FastRPC session is shared.

Three layers of defense:

### C++ global: `LibAppBuilder.cpp`
- Record QNN owner PID (`sg_qnnOwnerPid`) on first backend init
- 5 public APIs (`ModelInitializeEx`, `ModelInferenceEx`, `ModelDestroyEx`, `SetPerfProfileGlobal`, `RelPerfProfileGlobal`) check `getpid()` at entry: return error or no-op in forked children

### C++ per-instance: `QnnInferenceEngine`
- Each engine records `m_creatorPid` in constructor
- Destructor skips all QNN teardown (`contextFree`, `backendFree`, `profileFree`, `logFree`) when PID mismatches — prevents inherited FastRPC fd operations from corrupting parent

### Python: `qnncontext.py`
- `_QNNContextBase` records `_creator_pid` at construction
- `_ensure_live()` raises a clear error message in forked children
- `release()` skips C++ destructor invocation in forked children (`self.m_context = None` without `del`, so pybind destructor is not triggered)

## Safety

- All guards are Linux-only (`#ifdef __linux__`), Windows is unaffected (no `fork()`)
- Purely additive: +112 lines, 0 existing lines modified, 4 files
- Each guard is a simple `getpid()` integer comparison — no mutex acquisition, no fd scanning, no dlopen/dlmopen
- Fork before QNN init is still allowed (`sg_qnnOwnerPid == -1`)
- Intentional resource leak in forked children is safe: OS reclaims on process exit

## Recommended usage

```python
import multiprocessing as mp
ctx = mp.get_context('spawn')  # avoids fork() entirely
p = ctx.Process(target=worker)
```