### PR TITLE
Split remote deployment install and start flows

### DIFF
--- a/tools/qaiappbuilder/interfaces/http/routes/remote_deploy.py
+++ b/tools/qaiappbuilder/interfaces/http/routes/remote_deploy.py
@@ -437,8 +437,12 @@ def build_router(*, container: "Container") -> APIRouter:
         # Drop the cached credentials for this instance — they are no
         # longer needed once the remote process and tunnel are stopped,
         # and leaving them would grow _DEPLOY_HOSTS unboundedly across
-        # repeated deploy/stop cycles.
-        _DEPLOY_HOSTS.pop(instance_id, None)
+        # repeated deploy/stop cycles. Only on confirmed success: if the
+        # remote process could not be confirmed stopped, a retry needs the
+        # same credentials — dropping them here would strand it with no way
+        # to try again short of a full redeploy.
+        if result.stopped:
+            _DEPLOY_HOSTS.pop(instance_id, None)
         return StopInstanceResponse(
             instance_id=result.instance_id,
             stopped=result.stopped,

--- a/tools/qaiappbuilder/src/qai/remote_deploy/application/use_cases/__init__.py
+++ b/tools/qaiappbuilder/src/qai/remote_deploy/application/use_cases/__init__.py
@@ -206,6 +206,12 @@ class InstallRemoteUseCase:
             f"    '{_RELEASE_URL}' -o /tmp/qaiappbuilder.zip && "
             f"  unzip -qo /tmp/qaiappbuilder.zip -d \"$_TMP\" && "
             f"  rm -f /tmp/qaiappbuilder.zip && "
+            # If we got here, {_REMOTE_INSTALL_DIR}/start.sh does not exist (the
+            # ``if`` above would have skipped otherwise) — but the directory
+            # itself might, as a half-finished install left by a previous
+            # interrupted run. `mv` onto an existing directory nests the source
+            # inside it rather than replacing it, so clear it first.
+            f"  rm -rf {_REMOTE_INSTALL_DIR} && "
             # Handle both flat (start.sh at root) and nested (single subdir) zip layouts
             f"  if [ -f \"$_TMP/start.sh\" ]; then "
             f"    mv \"$_TMP\" {_REMOTE_INSTALL_DIR}; "
@@ -631,22 +637,48 @@ class StopInstanceUseCase:
             DeploymentState.RUNNING,
             DeploymentState.STARTING,
         )
+        stopped = True
         if was_live and remote is not None:
             # Prefer the PID captured at start. The fallback is scoped to this
             # service's own port so it can never take down an unrelated
             # process — a bare ``pkill -f start.sh`` would.
+            #
+            # Neither branch trusts the kill/pkill exit status — both routinely
+            # exit 0 while the process lingers (slow shutdown, ignored SIGTERM).
+            # So each polls for up to 5s, escalates to -9, and only reports
+            # ``DEAD`` once a final check confirms the process is actually gone.
+            # Without this, a failed stop looked identical to a successful one.
             if instance.remote_pid > 0:
-                command = f"kill {instance.remote_pid} 2>/dev/null || true"
-            else:
+                pid = instance.remote_pid
                 command = (
-                    f"pkill -f 'start.sh --port {instance.port}' 2>/dev/null || true"
+                    f"kill {pid} 2>/dev/null; "
+                    f"for i in 1 2 3 4 5; do kill -0 {pid} 2>/dev/null || break; sleep 1; done; "
+                    f"kill -0 {pid} 2>/dev/null && kill -9 {pid} 2>/dev/null; sleep 1; "
+                    f"kill -0 {pid} 2>/dev/null && echo STILL_ALIVE || echo DEAD"
                 )
-            await self.executor.run_command(remote, command, timeout=10)
+            else:
+                port = instance.port
+                command = (
+                    f"pkill -f 'start.sh --port {port}' 2>/dev/null; sleep 1; "
+                    f"pkill -9 -f 'start.sh --port {port}' 2>/dev/null; sleep 1; "
+                    f"ps -ef | grep '[s]tart.sh --port {port}' >/dev/null 2>&1 "
+                    f"&& echo STILL_ALIVE || echo DEAD"
+                )
+            _code, stdout, _stderr = await self.executor.run_command(
+                remote, command, timeout=20
+            )
+            stopped = "DEAD" in stdout
 
-        instance.state = DeploymentState.STOPPED
-        instance.remote_pid = 0
+        if stopped:
+            instance.state = DeploymentState.STOPPED
+            instance.remote_pid = 0
+        else:
+            instance.error_message = (
+                "Could not confirm the remote process stopped; it may still "
+                "be running."
+            )
         await self.repository.save(instance)
-        return StopInstanceResult(instance_id=instance_id, stopped=True)
+        return StopInstanceResult(instance_id=instance_id, stopped=stopped)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/qaiappbuilder/tests/unit/qai/remote_deploy/conftest.py
+++ b/tools/qaiappbuilder/tests/unit/qai/remote_deploy/conftest.py
@@ -70,6 +70,11 @@ class FakeSshExecutor:
             return 0, "PID:4242", ""
         if "curl -sf" in command:
             return 0, "READY", ""
+        if "STILL_ALIVE" in command:
+            # Stop's kill/pkill-and-verify probe — default to "the process
+            # died", i.e. the happy path. Tests exercising the "still alive
+            # after kill" path override this via a dedicated executor.
+            return 0, "DEAD", ""
         return 0, "", ""
 
     async def stream_command(
@@ -126,6 +131,23 @@ class OccupiedPortExecutor(FakeSshExecutor):
             return 0, "LISTEN 0 128 127.0.0.1:28688 users:(('other',pid=99))", ""
         if "echo HEALTHY" in command:
             return (0, "HEALTHY", "") if self.healthy else (1, "", "")
+        return 0, "", ""
+
+
+class StillAliveExecutor(FakeSshExecutor):
+    """Stop's kill/pkill-and-verify probe reports the process is still alive.
+
+    Reproduces a process that ignores both the initial signal and the -9
+    escalation (or a pkill pattern that never matched), so Stop must report
+    failure rather than assuming the fire-and-forget kill worked.
+    """
+
+    async def run_command(
+        self, host: RemoteHost, command: str, *, timeout: int = 300
+    ) -> tuple[int, str, str]:
+        self.commands.append(command)
+        if "STILL_ALIVE" in command:
+            return 0, "STILL_ALIVE", ""
         return 0, "", ""
 
 
@@ -203,6 +225,12 @@ def occupied_port_executor():
 def hanging_launch_executor():
     """The ``HangingLaunchExecutor`` class itself."""
     return HangingLaunchExecutor
+
+
+@pytest.fixture
+def still_alive_executor():
+    """The ``StillAliveExecutor`` class itself."""
+    return StillAliveExecutor
 
 
 @pytest.fixture

--- a/tools/qaiappbuilder/tests/unit/qai/remote_deploy/test_install_start_split.py
+++ b/tools/qaiappbuilder/tests/unit/qai/remote_deploy/test_install_start_split.py
@@ -114,6 +114,26 @@ async def test_install_failure_does_not_reach_installed(
     assert instance.state is DeploymentState.FAILED
 
 
+async def test_install_clears_a_half_installed_directory_before_moving_in(
+    fake_executor, repository
+) -> None:
+    """A previous interrupted install can leave ``~/qaiappbuilder`` without
+    ``start.sh``. ``mv`` onto an existing directory nests the source inside
+    it instead of replacing it, so the download step must clear the target
+    first.
+    """
+    executor = fake_executor()
+    install = InstallRemoteUseCase(executor=executor, repository=repository)
+
+    await _drain(install.stream(**_KWARGS))
+
+    download_cmd = executor.command_matching("curl -fsSL")
+    assert "rm -rf ~/qaiappbuilder" in download_cmd
+    assert download_cmd.index("rm -rf ~/qaiappbuilder") < download_cmd.index(
+        'mv "$_TMP"'
+    )
+
+
 # ---------------------------------------------------------------------------
 # Start
 # ---------------------------------------------------------------------------
@@ -284,3 +304,24 @@ async def test_stop_unknown_instance_raises_not_found(
 
     with pytest.raises(RemoteInstanceNotFoundError):
         await stop.execute(instance_id="nope", remote=_remote())
+
+
+async def test_stop_reports_failure_when_process_survives_kill(
+    still_alive_executor, repository
+) -> None:
+    """``kill``/``pkill`` routinely exit 0 while the process lingers (slow
+    shutdown, ignored SIGTERM) — a non-error exit must not be reported as a
+    successful stop.
+    """
+    executor = still_alive_executor()
+    await _running_instance(repository, pid=4242)
+    stop = StopInstanceUseCase(executor=executor, repository=repository)
+
+    result = await stop.execute(instance_id="i-1", remote=_remote())
+
+    assert not result.stopped
+    instance = await repository.get("i-1")
+    assert instance is not None
+    assert instance.state is DeploymentState.RUNNING
+    assert instance.remote_pid == 4242
+    assert "Could not confirm" in instance.error_message


### PR DESCRIPTION
## Summary
- split remote deployment installation from service startup
- harden port ownership, stop, and hung-launch handling
- add regression coverage for the lifecycle transitions

## Verification
- `git diff --check` passed
- pytest could not run because pytest is not installed in the active Python environment

Closes #253