### PR TITLE
fix: prevent native crash on process exit from unordered QNN engine teardown

### DIFF
--- a/docs/guide_en.md
+++ b/docs/guide_en.md
@@ -34,6 +34,7 @@
    - 3.8 [Complete Example: Stable Diffusion Text-to-Image](#38-complete-example-stable-diffusion-text-to-image)
    - 3.9 [PerfProfile - Performance Mode Management](#39-perfprofile---performance-mode-management)
    - 3.10 [Native Mode Explained (High Performance)](#310-native-mode-explained-high-performance)
+   - 3.11 [Model Lifecycle & Process-Exit Cleanup](#311-model-lifecycle--process-exit-cleanup)
 
 4. [C++ API Reference](#4-c-api-reference)
    
@@ -1391,6 +1392,80 @@ outputs = model.Inference([input_data])
 # 6. Output is also in native type
 print(f"Output dtype: {outputs[0].dtype}")  # e.g., float16
 ```
+
+### 3.11 Model Lifecycle & Process-Exit Cleanup
+
+Every `QNNContext` / `QNNContextProc` owns a native QNN engine (context, backend, log, and
+device handles allocated on the Snapdragon NPU). This section documents how that native
+resource is released, and what changed starting with the process-exit-safety fix shipped in
+this version.
+
+#### Normal cleanup: `del` / going out of scope
+
+```python
+model = QNNContext(model_name, model_path)
+output = model.Inference([input_data])
+del model   # deterministically frees the native engine right away
+```
+
+`del model` (or letting `model` go out of scope so CPython collects it) is still the
+recommended way to free a model's NPU resources as soon as you are done with it. Calling
+`del`/letting the object be collected, and then having the interpreter's own garbage
+collector run again later, is safe — the native teardown is now idempotent: no matter how
+many times cleanup runs for a given model (explicit `del`, a second `del`, or a `gc.collect()`
+that revisits it), only the **first** attempt does any work; every subsequent one is a
+no-op that returns the same result.
+
+#### If you forget to `del` a model
+
+You do **not** need to explicitly `del` every model before your process exits. Starting with
+this version, `qai_appbuilder` automatically drains and destroys every model that is still
+alive when the Python interpreter shuts down (registered via `atexit`). This is what fixes a
+previous native crash that could occur on process exit when models were left un-destroyed —
+no application code change is required to get this protection; it applies to every process
+that imports `qai_appbuilder`.
+
+#### `_shutdown_all_models()` — explicit, process-wide shutdown
+
+```python
+from qai_appbuilder.appbuilder import _shutdown_all_models
+
+_shutdown_all_models()   # destroys every remaining QNN engine right now
+```
+
+`_shutdown_all_models()` is an optional, explicit API for applications/tests that want to
+force a full teardown of every model *before* process exit (for example, at the end of a
+test suite, or before unloading a plugin). Properties to know before using it:
+
+| Property | Behavior |
+| --- | --- |
+| Idempotent | Calling it again after everything is already shut down is a safe no-op. |
+| **Irreversible** | Once it completes, the native runtime is permanently in a "shut down" state for the lifetime of the process. It cannot be reset back to "running". |
+| Effect after shutdown | Every subsequent QNN-touching call — creating a new `QNNContext`, calling `.Inference()` on an existing one, `SetLogLevel()`, `SetPerfProfileGlobal()`, `RelPerfProfileGlobal()`, metadata getters (`getInputShapes()` etc.) — fails gracefully (returns `False` / an empty result) instead of raising or crashing. |
+| Reentrancy | Calling it from a thread that is itself inside an active AppBuilder call on the same thread (e.g. from inside your own code running underneath `Inference()`) raises `RuntimeError` — it cannot safely wait for an operation that is waiting on it. |
+| Failure reporting | Raises `RuntimeError` if one or more engines failed to tear down cleanly (the underlying native resources are still released best-effort; this surfaces the failure to the caller instead of hiding it). |
+
+> ⚠️ Because the shutdown is process-wide and permanent, only call `_shutdown_all_models()`
+> when your application is actually finished using QNN for the rest of the process's life
+> (e.g. immediately before `sys.exit()`, or at the very end of a test run). Do not call it
+> between unrelated pieces of work that each still need to create/use models — for that,
+> use `del` on the individual `QNNContext` objects you are done with instead.
+
+#### `_shutdown_all_models()` vs. `release_all()` — do not confuse these
+
+`qai_appbuilder` has two different, non-interchangeable cleanup helpers that sound similar:
+
+| | `qai_appbuilder.release_all()` | `qai_appbuilder.appbuilder._shutdown_all_models()` |
+| --- | --- | --- |
+| Layer | Python-side helper | Native (C++) runtime API |
+| Scope | Only Python `QNNContext`/`QNNContextProc`/Genie context objects your process currently holds a live reference to | Every native QNN engine registered in the process, regardless of whether Python still holds a reference |
+| Reversible afterwards? | Yes — you can create new `QNNContext` objects afterward | **No** — permanently ends the native runtime for the process (see above) |
+| Typical use | Best-effort cleanup before/around `fork()` in multi-process setups | One-time, final teardown right before process exit or in test teardown |
+
+If you only need to release the Python objects you already have references to (and intend to
+keep using `qai_appbuilder` afterward), use `release_all()`. If you want to guarantee every
+native engine is gone and you are finished with `qai_appbuilder` for the rest of the process,
+use `_shutdown_all_models()`.
 
 ---
 

--- a/docs/guide_zh.md
+++ b/docs/guide_zh.md
@@ -34,6 +34,7 @@
    - 3.8 [完整示例：Stable Diffusion 文生图](#38-完整示例stable-diffusion-文生图)
    - 3.9 [PerfProfile - 性能模式管理](#39-perfprofile---性能模式管理)
    - 3.10 [Native 模式详解（高性能）](#310-native-模式详解高性能)
+   - 3.11 [模型生命周期与进程退出清理](#311-模型生命周期与进程退出清理)
 
 4. [C++ API 详解](#4-c-api-详解)
    
@@ -1392,6 +1393,76 @@ outputs = model.Inference([input_data])
 # 6. 输出也是原生类型
 print(f"Output dtype: {outputs[0].dtype}")  # 例如：float16
 ```
+
+### 3.11 模型生命周期与进程退出清理
+
+每个 `QNNContext` / `QNNContextProc` 都持有一个原生 QNN engine（在骁龙 NPU 上分配的 context、
+backend、log、device 等 handle）。本节说明这个原生资源如何释放，以及本版本内附带的
+"进程退出安全"修复带来了哪些新增内容。
+
+#### 正常清理：`del` / 超出作用域
+
+```python
+model = QNNContext(model_name, model_path)
+output = model.Inference([input_data])
+del model   # 立即、确定性地释放原生 engine
+```
+
+`del model`（或让 `model` 超出作用域被 CPython 回收）仍然是"用完立即释放该模型 NPU
+资源"的推荐方式。多次触发清理（显式 `del`、再次 `del`、或之后又跑一次 `gc.collect()`
+重新访问到它）是安全的——原生 teardown 现在是幂等的：不论对同一个模型的清理跑了多少次，
+只有**第一次**真正做事，之后每一次都是返回同一结果的空操作。
+
+#### 如果忘记 `del` 某个模型
+
+并**不需要**在进程退出前手动 `del` 每一个模型。从本版本开始，`qai_appbuilder` 会在 Python
+解释器退出时（通过 `atexit` 注册）自动 drain 并销毁所有仍然存活的模型。这正是用来修复此前
+"模型未销毁就退出进程"时可能触发的原生崩溃——不需要应用代码做任何改动即可获得这个保护，
+任何 import 了 `qai_appbuilder` 的进程都会自动受益。
+
+#### `_shutdown_all_models()` —— 显式的、进程级的关闭
+
+```python
+from qai_appbuilder.appbuilder import _shutdown_all_models
+
+_shutdown_all_models()   # 立即销毁所有剩余的 QNN engine
+```
+
+`_shutdown_all_models()` 是一个可选的显式 API，供想在进程退出**之前**强制完整销毁所有模型的
+应用/测试使用（例如测试套件结束时，或卸载插件之前）。使用前需要了解以下特性：
+
+| 特性 | 行为 |
+| --- | --- |
+| 幂等 | 全部关闭后再调用一次是安全的空操作。 |
+| **不可逆** | 一旦执行完成，原生 runtime 在该进程剩余生命周期内永久处于"已关闭"状态，无法重置回"运行中"。 |
+| 关闭后的影响 | 之后任何触碰 QNN 的调用——新建 `QNNContext`、对已有对象调用 `.Inference()`、
+  `SetLogLevel()`、`SetPerfProfileGlobal()`、`RelPerfProfileGlobal()`、元数据 getter
+  （`getInputShapes()` 等）——都会优雅失败（返回 `False` / 空结果），而不是抛异常或崩溃。 |
+| 重入 | 如果在同一线程内、从一个正处于某个 AppBuilder 调用内部的代码（例如 `Inference()`
+  内部调用到的自定义代码）调用它，会抛 `RuntimeError`——它不能安全地等待一个正在等待它自己
+  的操作。 |
+| 失败上报 | 如果有一个或多个 engine 未能干净地完成 teardown，会抛 `RuntimeError`（底层
+  原生资源仍会尽力释放；这样做是为了把失败暴露给调用方，而不是隐藏它）。 |
+
+> ⚠️ 由于这个关闭是进程级、永久性的，只应在应用**确实在该进程剩余生命周期内不再使用 QNN**
+> 时才调用 `_shutdown_all_models()`（例如紧接着 `sys.exit()` 之前，或测试跑完的最后一步）。
+> 不要在两段还各自需要创建/使用模型的不相关工作之间调用它——那种场景应改用对具体
+> `QNNContext` 对象的 `del`。
+
+#### `_shutdown_all_models()` 与 `release_all()` 的区别 —— 不要混淆
+
+`qai_appbuilder` 有两个名字相似但**不可互相替代**的清理辅助函数：
+
+| | `qai_appbuilder.release_all()` | `qai_appbuilder.appbuilder._shutdown_all_models()` |
+| --- | --- | --- |
+| 层级 | Python 侧辅助函数 | 原生（C++）runtime API |
+| 作用范围 | 仅限当前进程 Python 侧仍持有存活引用的 `QNNContext`/`QNNContextProc`/Genie context 对象 | 进程内注册的**所有**原生 QNN engine，无论 Python 端是否还持有引用 |
+| 之后可逆吗？ | 可以——之后仍可创建新的 `QNNContext` | **不可以**——永久结束该进程的原生 runtime（见上） |
+| 典型用途 | 多进程场景下 `fork()` 前后的尽力清理 | 进程退出前、或测试收尾时的一次性最终 teardown |
+
+如果你只需要释放当前手上还持有引用的 Python 对象（之后还打算继续使用
+`qai_appbuilder`），用 `release_all()`。如果你要确保所有原生 engine 都被销毁、并且之后
+这个进程不再使用 `qai_appbuilder`，用 `_shutdown_all_models()`。
 
 ---
 

--- a/pybind/AppBuilder.cpp
+++ b/pybind/AppBuilder.cpp
@@ -10,6 +10,7 @@
 #include "common.h"
 #include "Lora.hpp"
 #include <ostream>
+#include <stdexcept>
 
 ShareMemory::ShareMemory(const std::string& share_memory_name, const size_t share_memory_size) {
     m_share_memory_name = share_memory_name;
@@ -235,6 +236,9 @@ bool QNNContext::ApplyBinaryUpdate(const std::vector<LoraAdapter>& lora_adapters
 }
 
 PYBIND11_MODULE(appbuilder, m) {
+    // Initialize all process-lifetime stores now, while normal module import
+    // can report allocation failure and before Python registers atexit work.
+    InitializeRuntimeLifecycleStores();
     m.doc() = R"pbdoc(
         Pybind11 AppBuilder Extension.
         -----------------------
@@ -317,5 +321,24 @@ PYBIND11_MODULE(appbuilder, m) {
 
     py::class_<LoraAdapter>(m, "LoraAdapter")
         .def(py::init<const std::string &, const std::vector<std::string> &>());
+
+    // Explicit shutdown API for applications and tests. A shutdown attempted
+    // from an active runtime operation cannot safely wait for itself.
+    m.def("_shutdown_all_models", []() {
+        const auto result = ShutdownAllModels();
+        if (result == ShutdownAllModelsStatus::InActiveOperation) {
+            throw std::runtime_error("_shutdown_all_models cannot run inside an active AppBuilder operation");
+        }
+        if (result == ShutdownAllModelsStatus::Failed) {
+            throw std::runtime_error("_shutdown_all_models failed while destroying one or more QNN engines");
+        }
+    }, "Destroy all remaining QNN engines. Idempotent.");
+
+    // Python atexit is best-effort only: it never throws during interpreter
+    // finalization, and all lifecycle stores were initialized above.
+    auto atexit_mod = py::module_::import("atexit");
+    atexit_mod.attr("register")(py::cpp_function([]() noexcept {
+        (void)ShutdownAllModels();
+    }));
 }
 

--- a/src/LibAppBuilder.cpp
+++ b/src/LibAppBuilder.cpp
@@ -12,7 +12,11 @@
 #include <chrono>
 #include <unordered_map>
 #include <mutex>
-#include <iostream>
+#include <atomic>
+#include <condition_variable>
+#include <optional>
+#include <type_traits>
+#include <utility>
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -69,14 +73,177 @@ static bool gs_isGpu = false;
 static bool gs_isCpu = false;
 static bool sg_perf_global = false;
 
-std::unordered_map<std::string, std::unique_ptr<qnn_app::QnnInferenceEngine>> sg_model_map;
-// Guards sg_model_map only. The map is mutated (erase on take, insert on
-// return) by every ModelInference/ModelInitialize call. When two pipeline
-// threads run different models concurrently (e.g. model a on HTP0 + model 1 on HTP1),
-// their erase/insert on this shared map race and corrupt its bucket list.
-// This mutex serializes ONLY the map find/erase/insert; executeGraphsBuffers
-// (the actual HTP inference) runs OUTSIDE the lock, so parallelism is kept.
-static std::mutex sg_model_map_mutex;
+// Intentionally process-lifetime allocated (never enters CRT static
+// destruction).  If atexit / ShutdownAllModels() runs, the map is drained
+// and engines are properly torn down.  If atexit does NOT run (os._exit,
+// fatal signal, etc.), the map leaks harmlessly — the OS reclaims the
+// address space on process termination, and we avoid calling QNN APIs in
+// the uncontrolled DLL/CRT teardown phase where provider state is
+// indeterminate.  This is safer than letting ~unordered_map destroy
+// engines whose QNN backend may already be gone.
+using EngineMap = std::unordered_map<std::string,
+                                     std::unique_ptr<qnn_app::QnnInferenceEngine>>;
+
+// These stores deliberately have process lifetime so their destructors cannot
+// call QNN during CRT/DLL teardown.  They may allocate; callers must therefore
+// initialize them during normal module startup, not from an atexit callback.
+static EngineMap& sg_model_map() {
+    static EngineMap* map = new EngineMap();
+    return *map;
+}
+static std::mutex& sg_model_map_mutex() {
+    static std::mutex* mtx = new std::mutex();
+    return *mtx;
+}
+
+// ---------------------------------------------------------------------------
+// Process-exit safety: runtime lifecycle + unified teardown
+// ---------------------------------------------------------------------------
+enum class RuntimeState { Running, ShuttingDown, Shutdown };
+
+struct RuntimeLifecycle {
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::atomic<RuntimeState> state{RuntimeState::Running};
+    std::size_t activeOperations{0};
+    ShutdownAllModelsStatus shutdownResult{ShutdownAllModelsStatus::Failed};
+};
+
+// Process-lifetime allocated — same rationale as the engine registry.
+static RuntimeLifecycle& sg_runtime() {
+    static RuntimeLifecycle* rt = new RuntimeLifecycle();
+    return *rt;
+}
+
+// Counts guards held by this thread.  Shutdown must not wait for an operation
+// that is blocked in that same shutdown call.
+static thread_local std::size_t sg_runtimeOperationDepth{0};
+
+void InitializeRuntimeLifecycleStores() {
+    (void)sg_model_map();
+    (void)sg_model_map_mutex();
+    (void)sg_runtime();
+}
+
+// Covers one extract-use-return operation. Acquire before extracting or
+// creating an engine; keep it alive until putQnnApp() has returned (or the
+// extracted unique_ptr has been destroyed). This lets shutdown swap the
+// registry without ever nesting lifecycle and registry mutexes.
+class RuntimeOperationGuard {
+public:
+    static std::optional<RuntimeOperationGuard> acquire() noexcept {
+        auto& rt = sg_runtime();
+        if (rt.state.load(std::memory_order_acquire) != RuntimeState::Running) {
+            return std::nullopt;
+        }
+        std::lock_guard<std::mutex> lock(rt.mutex);
+        if (rt.state.load(std::memory_order_relaxed) != RuntimeState::Running) {
+            return std::nullopt;
+        }
+        ++rt.activeOperations;
+        ++sg_runtimeOperationDepth;
+        return RuntimeOperationGuard{};
+    }
+
+    RuntimeOperationGuard(RuntimeOperationGuard&& other) noexcept
+        : m_active(std::exchange(other.m_active, false)) {}
+    RuntimeOperationGuard& operator=(RuntimeOperationGuard&&) = delete;
+    RuntimeOperationGuard(const RuntimeOperationGuard&) = delete;
+    RuntimeOperationGuard& operator=(const RuntimeOperationGuard&) = delete;
+
+    ~RuntimeOperationGuard() noexcept {
+        if (!m_active) return;
+        auto& rt = sg_runtime();
+        {
+            std::lock_guard<std::mutex> lock(rt.mutex);
+            --rt.activeOperations;
+            --sg_runtimeOperationDepth;
+        }
+        rt.cv.notify_all();
+    }
+
+private:
+    RuntimeOperationGuard() = default;
+    bool m_active{true};
+};
+
+/// Destroy one engine — delegates to the engine's own idempotent shutdown().
+static bool DestroyEngineSafely(
+    const std::string& /*model_name*/,
+    std::unique_ptr<qnn_app::QnnInferenceEngine> engine) noexcept
+{
+    if (!engine) return true;
+    const bool succeeded = engine->shutdown() == qnn_app::StatusCode::SUCCESS;
+    engine.reset();
+    return succeeded;
+}
+
+static_assert(
+    noexcept(std::declval<EngineMap&>().swap(std::declval<EngineMap&>())),
+    "EngineMap::swap must be noexcept for shutdown safety");
+
+/// Drain the engine registry and perform full teardown. Operations which have
+/// extracted an engine finish before the registry is swapped.
+static ShutdownAllModelsStatus ShutdownAllModelsImpl()
+{
+    if (sg_runtimeOperationDepth != 0) {
+        return ShutdownAllModelsStatus::InActiveOperation;
+    }
+
+    EngineMap engines;
+    auto& rt = sg_runtime();
+    {
+        std::unique_lock<std::mutex> lock(rt.mutex);
+        const auto state = rt.state.load(std::memory_order_relaxed);
+        if (state == RuntimeState::Shutdown) return rt.shutdownResult;
+        if (state == RuntimeState::ShuttingDown) {
+            rt.cv.wait(lock, [&rt] {
+                return rt.state.load(std::memory_order_acquire) == RuntimeState::Shutdown;
+            });
+            return rt.shutdownResult;
+        }
+        rt.state.store(RuntimeState::ShuttingDown, std::memory_order_release);
+        rt.cv.wait(lock, [&rt] { return rt.activeOperations == 0; });
+    }
+
+    // Lock invariant: lifecycle and registry mutexes are never held together.
+    // Guards prevent extraction/insertion after state becomes ShuttingDown.
+    {
+        std::lock_guard<std::mutex> lock(sg_model_map_mutex());
+        engines.swap(sg_model_map());
+    }
+
+    auto result = ShutdownAllModelsStatus::Completed;
+    for (auto& [name, engine] : engines) {
+        if (!DestroyEngineSafely(name, std::move(engine))) {
+            result = ShutdownAllModelsStatus::Failed;
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(rt.mutex);
+        rt.shutdownResult = result;
+        rt.state.store(RuntimeState::Shutdown, std::memory_order_release);
+    }
+    rt.cv.notify_all();
+    return result;
+}
+
+extern "C" ShutdownAllModelsStatus ShutdownAllModels() noexcept
+{
+    try {
+        return ShutdownAllModelsImpl();
+    } catch (...) {
+        auto& rt = sg_runtime();
+        {
+            std::lock_guard<std::mutex> lock(rt.mutex);
+            rt.shutdownResult = ShutdownAllModelsStatus::Failed;
+            rt.state.store(RuntimeState::Shutdown, std::memory_order_release);
+        }
+        rt.cv.notify_all();
+        return ShutdownAllModelsStatus::Failed;
+    }
+}
 static qnn_app::ProfilingLevel sg_parsedProfilingLevel = qnn_app::ProfilingLevel::OFF;
 
 namespace qnn {
@@ -186,25 +353,34 @@ std::unique_ptr<qnn_app::QnnInferenceEngine> initQnnInferenceEngine(std::string 
 
 
 std::unique_ptr<qnn_app::QnnInferenceEngine> getQnnInferenceEngine(std::string model_name) {
-  std::lock_guard<std::mutex> lk(sg_model_map_mutex);
-  auto it = sg_model_map.find(model_name);
-  if (it != sg_model_map.end()) {
+  std::lock_guard<std::mutex> lk(sg_model_map_mutex());
+  auto it = sg_model_map().find(model_name);
+  if (it != sg_model_map().end()) {
     if (it->second) {
       auto app = std::move(it->second);
-      sg_model_map.erase(it);
+      sg_model_map().erase(it);
       return app;
     }
   }
   return nullptr;
 }
 
-// Symmetric counterpart to getQnnInferenceEngine: re-insert the app under the same
-// lock. Replaces the bare `sg_model_map.insert(...)` calls scattered across
-// ModelInference/ModelInitialize so every map mutation is serialized.
-void putQnnApp(std::string model_name,
-                     std::unique_ptr<qnn_app::QnnInferenceEngine> app) {
-  std::lock_guard<std::mutex> lk(sg_model_map_mutex);
-  sg_model_map.insert(std::make_pair(std::move(model_name), std::move(app)));
+// Symmetric counterpart to getQnnInferenceEngine. The caller's
+// RuntimeOperationGuard prevents shutdown from swapping the registry until
+// this insertion completes, so this function only ever acquires registry state.
+// When insertion fails, the by-value app parameter is destroyed on return;
+// QnnInferenceEngine's destructor invokes its idempotent shutdown().
+bool putQnnApp(std::string model_name,
+               std::unique_ptr<qnn_app::QnnInferenceEngine> app) noexcept {
+  if (!app) return false;
+  try {
+    std::lock_guard<std::mutex> lock(sg_model_map_mutex());
+    auto [it, inserted] = sg_model_map().try_emplace(
+        std::move(model_name), std::move(app));
+    return inserted;
+  } catch (...) {
+    return false;
+  }
 }
 void SetProcInfo(std::string proc_name, uint64_t epoch) {
     setEpoch(epoch);
@@ -218,6 +394,8 @@ bool SetProfilingLevel(int32_t profiling_level) {
 }
 
 bool SetLogLevel(int32_t log_level, const std::string log_path) {
+  auto operation = RuntimeOperationGuard::acquire();
+  if (!operation) return false;
 #ifdef _WIN32
   if(log_path != "" && log_path != "None") {
     if (_access(log_path.c_str(), 0) == 0) {
@@ -256,6 +434,11 @@ bool SetLogLevel(int32_t log_level, const std::string log_path) {
 }
 
 bool SetPerfProfileGlobal(const std::string& perf_profile) {
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) {
+        QNN_ERR("SetPerfProfileGlobal: runtime is shutting down.\n");
+        return false;
+    }
 #ifdef __linux__
     if (isForkedChildWithInheritedQnnState()) {
         QNN_WARN("SetPerfProfileGlobal: skipping in fork()ed child (issue#97).\n");
@@ -299,6 +482,8 @@ bool SetPerfProfileGlobal(const std::string& perf_profile) {
 }
 
 bool RelPerfProfileGlobal() {
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) return false;
 #ifdef __linux__
     if (isForkedChildWithInheritedQnnState()) {
         QNN_WARN("RelPerfProfileGlobal: skipping in fork()ed child (issue#97).\n");
@@ -490,6 +675,11 @@ bool ModelInitializeEx(const std::string& model_name, const std::string& proc_na
                        const std::string& backend_lib_path, const std::string& system_lib_path, 
                        std::vector<LoraAdapter>& lora_adapters,
                        bool async, const std::string& input_data_type, const std::string& output_data_type, uint32_t deviceID=0, std::string coreIdsStr="", const std::vector<std::string>& enable_graphs={}) {
+  auto operation = RuntimeOperationGuard::acquire();
+  if (!operation) {
+      QNN_ERR("ModelInitializeEx: runtime is shutting down, cannot create new engine.\n");
+      return false;
+  }
   QNN_INFO("LibAppBuilder::ModelInitialize: %s \n", model_name.c_str());
 
 #ifdef __linux__
@@ -667,7 +857,10 @@ bool ModelInitializeEx(const std::string& model_name, const std::string& proc_na
 
     timerHelper.Print("model_initialize " + model_name);
 
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+      QNN_ERR("ModelInitializeEx: failed to register initialized model: %s\n", model_name.c_str());
+      return false;
+    }
 
     return true;
   }
@@ -679,6 +872,11 @@ bool ModelInferenceEx(std::string model_name, std::string proc_name, std::string
                       std::vector<uint8_t*>& inputBuffers, std::vector<size_t>& inputSize,
                       std::vector<uint8_t*>& outputBuffers, std::vector<size_t>& outputSize,
                       std::string& perfProfile, size_t graphIndex, size_t share_memory_size=0) {
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) {
+        QNN_ERR("ModelInferenceEx: runtime is shutting down.\n");
+        return false;
+    }
     bool result = true;
 
     QNN_INFO("LibAppBuilder::ModelInference: %s \n", model_name.c_str());
@@ -713,7 +911,10 @@ bool ModelInferenceEx(std::string model_name, std::string proc_name, std::string
         result = false;
     }
 
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+        QNN_ERR("ModelInferenceEx: failed to restore model after inference: %s\n", model_name.c_str());
+        return false;
+    }
 
     timerHelper.Print("model_inference " + model_name);
 
@@ -731,6 +932,11 @@ bool ModelDestroyEx(std::string model_name, std::string proc_name) {
     }
 #endif
 
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) {
+        QNN_ERR("ModelDestroyEx: runtime is shutting down.\n");
+        return false;
+    }
     bool result = false;
 
     if (!proc_name.empty()) {
@@ -743,45 +949,18 @@ bool ModelDestroyEx(std::string model_name, std::string proc_name) {
 
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {
-        // issue#109/#4: the model was never registered or has already been
-        // destroyed/taken. Do NOT dereference the null app (the original code
-        // called app->reportError here, which crashed on a repeated destroy).
         QNN_WARN("ModelDestroy: can't find the model with model_name: %s (already destroyed?)\n", model_name.c_str());
         return false;
     }
 
-    // improve performance.
-    if (qnn_app::StatusCode::SUCCESS != app->tearDownInputAndOutputTensors()) {
-        app->reportError("Input and Output Tensors destroy failure");
-        return false;
-    }
-
-    if (qnn_app::StatusCode::SUCCESS != app->destroyPerformance()) {
-        app->reportError("Performance destroy failure");
-        return false;
-    }
-
-    if (qnn_app::StatusCode::SUCCESS != app->freeGraphs()) {
-        app->reportError("Free graphs failure");
-        return false;
-    }
-
-    if (qnn_app::StatusCode::SUCCESS != app->freeContext()) {
-        app->reportError("Context Free failure");
-        return false;
-    }
-
-    auto devicePropertySupportStatus = app->isDevicePropertySupported();
-    if (qnn_app::StatusCode::FAILURE != devicePropertySupportStatus) {
-        auto freeDeviceStatus = app->freeDevice();
-        if (qnn_app::StatusCode::SUCCESS != freeDeviceStatus) {
-            app->reportError("Device Free failure");
-            return false;
-        }
-    }
+    // Unified teardown — the engine's own idempotent shutdown() handles
+    // the complete resource release sequence.  No need to call individual
+    // free functions here; that was the source of double-free risks when
+    // the destructor also released the same handles.
+    auto status = app->shutdown();
     timerHelper.Print("model_destroy " + model_name);
 
-    return true;
+    return (qnn_app::StatusCode::SUCCESS == status);
 }
 
 
@@ -856,6 +1035,11 @@ bool LibAppBuilder::ModelWaitInference(const std::string& request_id,
 }
 
 bool LibAppBuilder::ModelApplyBinaryUpdate(const std::string model_name, std::vector<LoraAdapter>& lora_adapters) {
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) {
+        QNN_ERR("ModelApplyBinaryUpdate: runtime is shutting down.\n");
+        return false;
+    }
     bool result = true;
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {
@@ -874,7 +1058,10 @@ bool LibAppBuilder::ModelApplyBinaryUpdate(const std::string model_name, std::ve
         result = false;
     }
 
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+        QNN_ERR("ModelApplyBinaryUpdate: failed to restore model: %s\n", model_name.c_str());
+        return false;
+    }
 
     return result;
 }
@@ -900,79 +1087,114 @@ bool LibAppBuilder::DeleteShareMemory(std::string share_memory_name) {
 
 // issue#24
 std::vector<std::vector<size_t>> LibAppBuilder::getOutputShapes(std::string model_name, size_t graphIdx){
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) return {};
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4: guard against released/missing context.
         QNN_WARN("getOutputShapes: model not found or released: %s\n", model_name.c_str());
         return {};
     }
     m_outputShapes = app->getOutputShapes(graphIdx);
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+        QNN_ERR("getOutputShapes: failed to restore model: %s\n", model_name.c_str());
+        return {};
+    }
     return m_outputShapes;
 };
 
 std::vector<std::vector<size_t>> LibAppBuilder::getInputShapes(std::string model_name, size_t graphIdx){
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) return {};
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getInputShapes: model not found or released: %s\n", model_name.c_str());
         return {};
     }
     m_inputShapes = app->getInputShapes(graphIdx);
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+        QNN_ERR("getInputShapes: failed to restore model: %s\n", model_name.c_str());
+        return {};
+    }
     return m_inputShapes;
 };
 
 std::vector<std::string> LibAppBuilder::getInputDataType(std::string model_name, size_t graphIdx){
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) return {};
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getInputDataType: model not found or released: %s\n", model_name.c_str());
         return {};
     }
     m_inputDataType = app->getInputDataType(graphIdx);
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+        QNN_ERR("getInputDataType: failed to restore model: %s\n", model_name.c_str());
+        return {};
+    }
     return m_inputDataType;
 };
 
 std::vector<std::string> LibAppBuilder::getOutputDataType(std::string model_name, size_t graphIdx){
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) return {};
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getOutputDataType: model not found or released: %s\n", model_name.c_str());
         return {};
     }
     m_outputDataType = app->getOutputDataType(graphIdx);
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+        QNN_ERR("getOutputDataType: failed to restore model: %s\n", model_name.c_str());
+        return {};
+    }
     return m_outputDataType;
 };
 
 std::string LibAppBuilder::getGraphName(std::string model_name, size_t graphIdx){
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) return {};
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getGraphName: model not found or released: %s\n", model_name.c_str());
         return {};
     }
     m_graphName = app->getGraphName(graphIdx);
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+        QNN_ERR("getGraphName: failed to restore model: %s\n", model_name.c_str());
+        return {};
+    }
     return m_graphName;
 };
 
 std::vector<std::string> LibAppBuilder::getInputName(std::string model_name, size_t graphIdx){
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) return {};
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getInputName: model not found or released: %s\n", model_name.c_str());
         return {};
     }
     m_inputName = app->getInputName(graphIdx);
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+        QNN_ERR("getInputName: failed to restore model: %s\n", model_name.c_str());
+        return {};
+    }
     return m_inputName;
 };
 
 std::vector<std::string> LibAppBuilder::getOutputName(std::string model_name, size_t graphIdx){
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) return {};
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
         QNN_WARN("getOutputName: model not found or released: %s\n", model_name.c_str());
         return {};
     }
     m_outputName = app->getOutputName(graphIdx);
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+        QNN_ERR("getOutputName: failed to restore model: %s\n", model_name.c_str());
+        return {};
+    }
     return m_outputName;
 };
 //proc
@@ -1025,6 +1247,8 @@ ModelInfo_t LibAppBuilder::getModelInfo(std::string model_name, std::string inpu
 ModelInfo_t LibAppBuilder::getModelInfoExt(std::string model_name, std::string input) {
     ModelInfo_t info;
 
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) return info;
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {
         // issue#109/#4: model missing/released. Return empty info without
@@ -1051,15 +1275,22 @@ ModelInfo_t LibAppBuilder::getModelInfoExt(std::string model_name, std::string i
         printf("wrong input in LibAppBuilder::getModelInfoExt: %s\n", input.c_str());
         app->reportError("getModelInfoExt failure");
         // Put the app back before returning so the model is not lost.
-        putQnnApp(model_name, std::move(app));
+        if (!putQnnApp(model_name, std::move(app))) {
+            QNN_ERR("getModelInfoExt: failed to restore model: %s\n", model_name.c_str());
+        }
         return info;
     }
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+        QNN_ERR("getModelInfoExt: failed to restore model: %s\n", model_name.c_str());
+        return {};
+    }
 
     return info;
 }
 
 uint64_t LibAppBuilder::getProfilingEvent(std::string model_name, uint32_t eventType){
+    auto operation = RuntimeOperationGuard::acquire();
+    if (!operation) return 0;
     uint64_t eventValue = 0;
     std::unique_ptr<qnn_app::QnnInferenceEngine> app = getQnnInferenceEngine(model_name);
     if (nullptr == app) {  // issue#109/#4
@@ -1067,7 +1298,10 @@ uint64_t LibAppBuilder::getProfilingEvent(std::string model_name, uint32_t event
         return 0;
     }
     eventValue = app->getProfilingEvent(eventType);
-    putQnnApp(model_name, std::move(app));
+    if (!putQnnApp(model_name, std::move(app))) {
+        QNN_ERR("getProfilingEvent: failed to restore model: %s\n", model_name.c_str());
+        return 0;
+    }
     return eventValue;
 }
 

--- a/src/LibAppBuilder.hpp
+++ b/src/LibAppBuilder.hpp
@@ -126,6 +126,22 @@ public:
     std::vector<std::string> m_outputName;
 };
 
+/////////////////////////////////////////////////////////////////////////////
+/// Process-exit safety: drain all QNN engines before DLL/CRT teardown.
+/// A shutdown requested by a thread inside a guarded operation returns
+/// InActiveOperation rather than waiting for itself.
+/////////////////////////////////////////////////////////////////////////////
+enum class ShutdownAllModelsStatus {
+    Completed,
+    InActiveOperation,
+    Failed,
+};
+
+/// Initialize process-lifetime lifecycle stores during normal startup. This
+/// must run before any atexit or shutdown callback can execute.
+LIBAPPBUILDER_API void InitializeRuntimeLifecycleStores();
+
+extern "C" LIBAPPBUILDER_API ShutdownAllModelsStatus ShutdownAllModels() noexcept;
 
 /////////////////////////////////////////////////////////////////////////////
 /// Class TimerHelper declaration.

--- a/src/QnnInferenceEngine.cpp
+++ b/src/QnnInferenceEngine.cpp
@@ -239,53 +239,111 @@ qnn_app::QnnInferenceEngine::QnnInferenceEngine(QnnFunctionPointers qnnFunctionP
   return;
 }
 
-qnn_app::QnnInferenceEngine::~QnnInferenceEngine() {
+// ---------------------------------------------------------------------------
+// Unified, idempotent teardown — the SINGLE code path for releasing all QNN
+// resources.  Both explicit ModelDestroyEx() and the destructor call this.
+// ---------------------------------------------------------------------------
+qnn_app::StatusCode qnn_app::QnnInferenceEngine::shutdown() noexcept {
+  bool expected = false;
+  if (!m_shutdownStarted.compare_exchange_strong(
+          expected, true, std::memory_order_acq_rel, std::memory_order_acquire)) {
+    std::unique_lock<std::mutex> lock(m_shutdownMutex);
+    m_shutdownCv.wait(lock, [this] { return m_shutdownComplete; });
+    return m_shutdownResult.load(std::memory_order_acquire);
+  }
+
+  StatusCode result = StatusCode::SUCCESS;
+  const auto complete = [this, &result]() noexcept {
+    m_shutdownResult.store(result, std::memory_order_release);
+    {
+      std::lock_guard<std::mutex> lock(m_shutdownMutex);
+      m_shutdownComplete = true;
+    }
+    m_shutdownCv.notify_all();
+    return result;
+  };
+
 #ifdef __linux__
-  // issue#97: this instance was inherited from a fork()ed parent. Do NOT call
-  // any QNN teardown APIs (contextFree, backendFree, profileFree, logFree) —
-  // they would operate on the parent's DSP/FastRPC session via inherited fds,
-  // corrupting the parent's state. The leaked resources are reclaimed by the
-  // OS when this child process exits.
-  if (m_creatorPid > 0 && getpid() != m_creatorPid) {
-      return;
-  }
+  // Inherited from a forked parent: never call QNN teardown in the child.
+  if (m_creatorPid > 0 && getpid() != m_creatorPid) return complete();
 #endif
-  // Free DLC resources using utility function
-  dlc_utils::freeDlcResources(m_qnnFunctionPointers.qnnSystemInterfaceHandle,
-                              m_dlcHandle,
-                              m_dlcLogHandle);
-  // Free Profiling object if it was created
-  if (nullptr != m_profileBackendHandle) {
-    QNN_DEBUG("Freeing backend profile object.");
-    if (QNN_PROFILE_NO_ERROR !=
-        m_qnnFunctionPointers.qnnInterface.profileFree(m_profileBackendHandle)) {
-      QNN_ERROR("Could not free backend profile handle.");
+
+  auto step = [&result](auto&& fn) noexcept {
+    try {
+      if (fn() != StatusCode::SUCCESS) result = StatusCode::FAILURE;
+    } catch (...) {
+      result = StatusCode::FAILURE;
     }
+  };
+
+  step([this] { return tearDownInputAndOutputTensors(); });
+  step([this] { return destroyPerformance(); });
+  step([this] { return freeGraphs(); });
+
+  if (m_isContextCreated || m_context != nullptr) {
+    step([this] { return freeContext(); });
+    m_context = nullptr;
+    m_isContextCreated = false;
   }
-  // Free context if not already done
-  if (m_isContextCreated) {
-    QNN_DEBUG("Freeing context");
-    if (QNN_CONTEXT_NO_ERROR !=
-        m_qnnFunctionPointers.qnnInterface.contextFree(m_context, nullptr)) {
-      QNN_ERROR("Could not free context");
+
+  // ── 5. Device ──
+  // Preserve AISW-149462 behaviour: freeDevice() intentionally does not
+  // release the shared device handle. Device ownership/refcount policy is
+  // independent of this exit-crash fix.
+  step([this] { return freeDevice(); });
+
+  // QAIRT 2.48: contextFree(context, profile) does not consume profile.
+  // Therefore it must precede profileFree(profile).
+  if (m_profileBackendHandle != nullptr) {
+    try {
+      if (m_qnnFunctionPointers.qnnInterface.profileFree == nullptr ||
+          m_qnnFunctionPointers.qnnInterface.profileFree(m_profileBackendHandle) != QNN_PROFILE_NO_ERROR) {
+        result = StatusCode::FAILURE;
+      }
+    } catch (...) {
+      result = StatusCode::FAILURE;
     }
+    m_profileBackendHandle = nullptr;
   }
-  m_isContextCreated = false;
-  // Terminate backend
-  if (m_isBackendInitialized && nullptr != m_qnnFunctionPointers.qnnInterface.backendFree) {
-    QNN_DEBUG("Freeing backend");
-    if (QNN_BACKEND_NO_ERROR != m_qnnFunctionPointers.qnnInterface.backendFree(m_backendHandle)) {
-      QNN_ERROR("Could not free backend");
+
+  if (m_isBackendInitialized || m_backendHandle != nullptr) {
+    try {
+      if (m_qnnFunctionPointers.qnnInterface.backendFree == nullptr ||
+          m_qnnFunctionPointers.qnnInterface.backendFree(m_backendHandle) != QNN_BACKEND_NO_ERROR) {
+        result = StatusCode::FAILURE;
+      }
+    } catch (...) {
+      result = StatusCode::FAILURE;
     }
+    m_backendHandle = nullptr;
+    m_isBackendInitialized = false;
   }
-  m_isBackendInitialized = false;
-  // Terminate logging in the backend
-  if (nullptr != m_qnnFunctionPointers.qnnInterface.logFree && nullptr != m_logHandle) {
-    if (QNN_SUCCESS != m_qnnFunctionPointers.qnnInterface.logFree(m_logHandle)) {
-      QNN_WARN("Unable to terminate logging in the backend.");
+
+  if (m_logHandle != nullptr) {
+    try {
+      if (m_qnnFunctionPointers.qnnInterface.logFree == nullptr ||
+          m_qnnFunctionPointers.qnnInterface.logFree(m_logHandle) != QNN_SUCCESS) {
+        result = StatusCode::FAILURE;
+      }
+    } catch (...) {
+      result = StatusCode::FAILURE;
     }
+    m_logHandle = nullptr;
   }
-  return;
+
+  try {
+    dlc_utils::freeDlcResources(m_qnnFunctionPointers.qnnSystemInterfaceHandle,
+                                m_dlcHandle, m_dlcLogHandle);
+  } catch (...) {
+    result = StatusCode::FAILURE;
+  }
+  m_dlcHandle = nullptr;
+  m_dlcLogHandle = nullptr;
+  return complete();
+}
+
+qnn_app::QnnInferenceEngine::~QnnInferenceEngine() noexcept {
+  (void)shutdown();
 }
 
 std::string qnn_app::QnnInferenceEngine::getBackendBuildId() {
@@ -442,7 +500,12 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::createContext() {
 
 // Free context after done.
 qnn_app::StatusCode qnn_app::QnnInferenceEngine::freeContext() {
-  // clear graph info first
+  // clear graph info first.  NOTE: shutdown() (the only current caller)
+  // always runs freeGraphs() before freeContext(), which already frees
+  // m_graphsInfo and sets it to nullptr — so this block is a no-op in that
+  // path. Kept for safety if freeContext() is ever called independently
+  // of the unified shutdown() sequence; do not remove without confirming
+  // no caller still relies on it to free un-freed graph info.
   if (m_graphsInfo) {
     for (uint32_t gIdx = 0; gIdx < m_graphsCount; gIdx++) {
       if (m_graphsInfo[gIdx]) {
@@ -760,7 +823,7 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::initializeProfileConfigOption(
     ProfilingOption profilingOption,
     Qnn_ProfileHandle_t profileHandle) {
     QNN_FUNCTION_ENTRY_LOG;
-    qnn_app::StatusCode returnStatus;
+    qnn_app::StatusCode returnStatus = qnn_app::StatusCode::FAILURE;
     QnnProfile_Config_t optraceConfig = QNN_PROFILE_CONFIG_INIT;
     if (profilingOption == qnn_app::ProfilingOption::OPTRACE) {
         optraceConfig.option = QNN_PROFILE_CONFIG_OPTION_ENABLE_OPTRACE;
@@ -793,7 +856,9 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::terminateProfileHandle(
     if (nullptr != profileHandle && nullptr != qnnInterfaceHandle->profileFree) {
         QNN_DEBUG("Freeing backend profile object.");
         auto result = qnnInterfaceHandle->profileFree(profileHandle);
-        QNN_ERROR("Could not free backend profile handle.");
+        if (QNN_PROFILE_NO_ERROR != result) {
+            QNN_ERROR("Could not free backend profile handle.");
+        }
         returnStatus = verifyFailReturnStatus(result);
     }
     QNN_FUNCTION_EXIT_LOG;
@@ -1425,7 +1490,6 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::createDevice() {
         auto qnnStatus =
           m_qnnFunctionPointers.qnnInterface.deviceCreate(m_logHandle, nullptr, &m_deviceHandle);
           if (QNN_SUCCESS != qnnStatus && QNN_DEVICE_ERROR_UNSUPPORTED_FEATURE != qnnStatus) {
-              // CPU backend may not support deviceCreate at all — treat as non-fatal and continue.
               QNN_WARN("CPU backend: deviceCreate returned error (0x%x), continuing without device handle", (unsigned int)qnnStatus);
               m_deviceHandle = nullptr;
           }
@@ -1479,12 +1543,20 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::createDevice() {
 
 qnn_app::StatusCode qnn_app::QnnInferenceEngine::freeDevice() {
   QNN_INFO("qnn_app::QnnInferenceEngine::freeDevice begin\n");
-  return StatusCode::SUCCESS; //AISW-149462
-
+  // INTENTIONAL — AISW-149462 resource-lifetime workaround.  The device
+  // handle is shared process-wide across model engines; releasing it from one
+  // engine's teardown can invalidate the handle while another engine still
+  // uses it, producing use-after-free/double-release failures.  Keep device
+  // ownership process-scoped and let process termination reclaim it.  The
+  // refcount/free implementation below is retained for diagnosis only and is
+  // deliberately unreachable.  Do not remove this early return or convert the
+  // handle to per-engine ownership without redesigning and validating the
+  // complete shared-device lifecycle across concurrent models.
+  return StatusCode::SUCCESS;
   const uint32_t deviceId = m_multiCoreDeviceConfig.deviceId;
   std::string devKey = makeDeviceKey(deviceId, m_multiCoreDeviceConfig.coreIdVec);
 
-  bool needRealFree = true; 
+  bool needRealFree = true;
   std::lock_guard<std::mutex> lk(devicesHandlesMutex);
   auto it = devicesHandles.find(devKey);
   auto rc = devicesRefCounts.find(devKey);
@@ -1494,7 +1566,7 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::freeDevice() {
       rc->second -= 1;
       QNN_INFO("Decreased refCount for key=%s (refCount=%u)\n",
                 devKey.c_str(), rc->second);
-      needRealFree = false; 
+      needRealFree = false;
     } else {
       rc->second = 0;
       devicesHandles.erase(it);
@@ -1513,6 +1585,7 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::freeDevice() {
     }
   }
   return StatusCode::SUCCESS;
+
 }
 
 // executeGraphs() that is currently used by qnn-sample-app's main.cpp.
@@ -1685,21 +1758,38 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::setupInputAndOutputTensors()
 // improve performance.
 qnn_app::StatusCode qnn_app::QnnInferenceEngine::tearDownInputAndOutputTensors()
 {
-  auto returnStatus = qnn::tools::iotensor::StatusCode::SUCCESS;
+  // A partially initialized engine may have no graph metadata or fewer
+  // tensor slots than m_graphsCount. Teardown must be safe from every
+  // constructor/initialization failure point because shutdown() is also the
+  // destructor path.
+  if (m_graphsInfo == nullptr || *m_graphsInfo == nullptr) {
+    m_inputTensors.clear();
+    m_outputTensors.clear();
+    return StatusCode::SUCCESS;
+  }
 
-  for (size_t graphIdx = 0; graphIdx < m_graphsCount; graphIdx++) {
+  auto returnStatus = qnn::tools::iotensor::StatusCode::SUCCESS;
+  const size_t initializedGraphs = std::min(
+      static_cast<size_t>(m_graphsCount),
+      std::min(m_inputTensors.size(), m_outputTensors.size()));
+
+  for (size_t graphIdx = 0; graphIdx < initializedGraphs; graphIdx++) {
     auto& graphInfo = (*m_graphsInfo)[graphIdx];
     Qnn_Tensor_t* inputs  = m_inputTensors[graphIdx];
     Qnn_Tensor_t* outputs = m_outputTensors[graphIdx];
-    returnStatus = m_ioTensor.tearDownInputAndOutputTensors(inputs, outputs, graphInfo.numInputTensors, graphInfo.numOutputTensors);
-    m_inputTensors[graphIdx]  = nullptr;
-    m_outputTensors[graphIdx]  = nullptr;
+    if (inputs != nullptr || outputs != nullptr) {
+      returnStatus = m_ioTensor.tearDownInputAndOutputTensors(
+          inputs, outputs, graphInfo.numInputTensors, graphInfo.numOutputTensors);
+    }
+    m_inputTensors[graphIdx] = nullptr;
+    m_outputTensors[graphIdx] = nullptr;
     if (qnn::tools::iotensor::StatusCode::SUCCESS != returnStatus) {
       QNN_ERROR("Error in tear down Input and output Tensors for graphIdx: %d", graphIdx);
       break;
     }
   }
-
+  m_inputTensors.clear();
+  m_outputTensors.clear();
   return static_cast<qnn_app::StatusCode>(returnStatus);
 }
 
@@ -2236,10 +2326,17 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::executeGraphsBuffers(std::vecto
 
 // zw.
 qnn_app::StatusCode qnn_app::QnnInferenceEngine::freeGraphs() {
-  qnn_wrapper_api::freeGraphsInfo(&m_graphsInfo, m_graphsCount);
+  if (m_graphsInfo == nullptr || *m_graphsInfo == nullptr) {
+    m_graphsInfo = nullptr;
+    m_graphsCount = 0;
+    return StatusCode::SUCCESS;
+  }
+  const auto status = qnn_wrapper_api::freeGraphsInfo(&m_graphsInfo, m_graphsCount);
   m_graphsInfo = nullptr;
-
-  return StatusCode::SUCCESS;
+  m_graphsCount = 0;
+  return status == qnn_wrapper_api::MODEL_NO_ERROR
+             ? StatusCode::SUCCESS
+             : StatusCode::FAILURE;
 }
 
 qnn_app::StatusCode qnn_app::QnnInferenceEngine::initializeLog() {
@@ -2276,11 +2373,7 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::initializePerformance() {
     Qnn_ErrorHandle_t infraStatus = m_qnnFunctionPointers.qnnInterface.deviceGetInfrastructure(&deviceInfra);
     if (QNN_SUCCESS != infraStatus) {
         if (QNN_DEVICE_ERROR_UNSUPPORTED_FEATURE == infraStatus) {
-            // Non-HTP backends (CPU) do not expose device power infrastructure.
-            // Set m_runInCpu=true so that destroyPerformance(), boostPerformance()
-            // and resetPerformance() short-circuit via their existing
-            // `if (true == m_runInCpu) return StatusCode::SUCCESS` guard —
-            // preventing a crash from uninitialized m_perfInfra/m_powerConfigId.
+            // Non-HTP backends do not expose device power infrastructure.
             m_runInCpu = true;
             return StatusCode::SUCCESS;
         }
@@ -2290,25 +2383,33 @@ qnn_app::StatusCode qnn_app::QnnInferenceEngine::initializePerformance() {
 
     QnnHtpDevice_Infrastructure_t* htpInfra = static_cast<QnnHtpDevice_Infrastructure_t*>(deviceInfra);
     m_perfInfra = htpInfra->perfInfra;
-    uint32_t deviceId = m_multiCoreDeviceConfig.deviceId; //0;
-    uint32_t coreId = m_multiCoreDeviceConfig.coreIdVec.empty()? 0 : *std::min_element(m_multiCoreDeviceConfig.coreIdVec.begin(), m_multiCoreDeviceConfig.coreIdVec.end()); //0;
-    QNN_INFO("qnn_app::QnnInferenceEngine::initializePerformance,deviceId=%u, coreId=%u\n",deviceId,coreId);
+    uint32_t deviceId = m_multiCoreDeviceConfig.deviceId;
+    uint32_t coreId = m_multiCoreDeviceConfig.coreIdVec.empty()
+                          ? 0
+                          : *std::min_element(m_multiCoreDeviceConfig.coreIdVec.begin(),
+                                              m_multiCoreDeviceConfig.coreIdVec.end());
+    QNN_INFO("qnn_app::QnnInferenceEngine::initializePerformance,deviceId=%u, coreId=%u\n", deviceId, coreId);
     if (QNN_SUCCESS != m_perfInfra.createPowerConfigId(deviceId, coreId, &m_powerConfigId)) {
         QNN_ERROR("Failure in createPowerConfigId()");
         return StatusCode::FAILURE;
     }
+    m_isPerformanceInitialized = true;
     sg_powerConfigIds.insert(m_powerConfigId);
     return StatusCode::SUCCESS;
 }
 
 qnn_app::StatusCode qnn_app::QnnInferenceEngine::destroyPerformance() {
-    if (true == m_runInCpu || m_isGpu)
+    if (!m_isPerformanceInitialized)
         return StatusCode::SUCCESS;
 
-    if (QNN_SUCCESS != m_perfInfra.destroyPowerConfigId(m_powerConfigId)) {
+    const auto status = m_perfInfra.destroyPowerConfigId(m_powerConfigId);
+    // Treat the opaque id as consumed regardless of backend status; retrying
+    // an indeterminate native handle risks double release.
+    m_isPerformanceInitialized = false;
+    sg_powerConfigIds.erase(m_powerConfigId);
+    if (QNN_SUCCESS != status) {
         QNN_ERROR("Failure in destroyPowerConfigId()");
         return StatusCode::FAILURE;
     }
-    sg_powerConfigIds.erase(m_powerConfigId);
     return StatusCode::SUCCESS;
 }

--- a/src/QnnInferenceEngine.hpp
+++ b/src/QnnInferenceEngine.hpp
@@ -10,7 +10,9 @@
 #include <memory>
 #include <queue>
 #include <map>
-
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include "IOTensor.hpp"
 #include "DynamicLoadUtil.hpp"
 #include "Lora.hpp"
@@ -165,8 +167,9 @@ class QnnInferenceEngine {
   std::vector<std::string> getInputName(size_t graphIdx = 0);
   std::vector<std::string> getOutputName(size_t graphIdx = 0);
   uint64_t getProfilingEvent(uint32_t eventType);
-  qnn_wrapper_api::GraphInfo_t **m_graphsInfo;
-  uint32_t m_graphsCount;
+  qnn_wrapper_api::GraphInfo_t **m_graphsInfo{nullptr};
+  uint32_t m_graphsCount{0};
+
 
   StatusCode initializeLog();
   StatusCode setLogLevel(QnnLog_Level_t logLevel);
@@ -178,7 +181,15 @@ class QnnInferenceEngine {
   StatusCode initializePerformance();
   StatusCode destroyPerformance();
 
-  virtual ~QnnInferenceEngine();
+  /// Unified, idempotent teardown.  Releases all QNN resources in the
+  /// correct dependency order (tensors → performance → graphs → context →
+  /// device → profile → backend → log → DLC).  Safe to call multiple
+  /// times — only the first call does work.  The destructor delegates to
+  /// this, so explicit callers and the destructor share ONE code path,
+  /// eliminating double-free risks.
+  StatusCode shutdown() noexcept;
+
+  virtual ~QnnInferenceEngine() noexcept;
 
  private:
   StatusCode extractBackendProfilingInfo(Qnn_ProfileHandle_t profileHandle);
@@ -228,7 +239,11 @@ class QnnInferenceEngine {
   uint32_t m_graphConfigsInfoCount;
   Qnn_LogHandle_t m_logHandle         = nullptr;
   Qnn_BackendHandle_t m_backendHandle = nullptr;
-  inline static Qnn_DeviceHandle_t m_deviceHandle   = nullptr;
+  // INTENTIONAL process-wide shared handle.  `freeDevice()` is a no-op under
+  // AISW-149462 because per-engine release can invalidate concurrent models;
+  // process termination owns final reclamation.  See freeDevice() before
+  // changing this to per-engine state.
+  inline static Qnn_DeviceHandle_t m_deviceHandle = nullptr;
   RunTimeAppKeys m_runTimeAppKeys;
   uint64_t m_numMaxEvents = std::numeric_limits<uint64_t>::max();
   std::vector<qnn_wrapper_api::GraphInfo_t*> m_graphInfoPtrList;
@@ -237,6 +252,7 @@ class QnnInferenceEngine {
 
   // zw.
   uint32_t m_powerConfigId = 1;
+  bool m_isPerformanceInitialized{false};
   QnnHtpDevice_PerfInfrastructure_t m_perfInfra = {nullptr};
   bool m_runInCpu = true;
   bool m_isGpu = false;
@@ -263,6 +279,14 @@ class QnnInferenceEngine {
   // detect inherited instances in fork()ed children and skip teardown.
   pid_t m_creatorPid{-1};
 #endif
+
+  /// Concurrent-safe shutdown guards. The first teardown result is retained
+  /// and returned by subsequent calls rather than being reported as success.
+  std::atomic<bool> m_shutdownStarted{false};
+  std::atomic<StatusCode> m_shutdownResult{StatusCode::FAILURE};
+  std::mutex m_shutdownMutex;
+  std::condition_variable m_shutdownCv;
+  bool m_shutdownComplete{false};
 };
 }  // namespace qnn_app
 }  // namespace tools


### PR DESCRIPTION
Fixes a native process-exit crash caused by the global QNN engine
registry (`unordered_map<string, unique_ptr<QnnInferenceEngine>>`)
being a plain static object. During CRT static destruction at process
exit, its destructor ran `~QnnInferenceEngine()` for every
still-registered engine, calling QNN teardown APIs
(`contextFree`/`backendFree`/`profileFree`/`logFree`) through cached
function pointers that may already point into an unloaded
`QnnHtp.dll`, and the destructor duplicated teardown steps already run
by an earlier explicit `ModelDestroyEx()`, risking a double-free.

## What changed

- The engine registry and its mutex are now process-lifetime allocated
  (leaked on purpose) so their destructors never run during CRT/DLL
  teardown; they are drained explicitly via a new
  `ShutdownAllModels()` / `atexit` hook instead.
- All QNN resource teardown is unified into a single idempotent
  `QnnInferenceEngine::shutdown()` (tensors -> performance -> graphs ->
  context -> device -> profile -> backend -> log -> DLC), called by
  both the destructor and `ModelDestroyEx()`. The first call's result
  is cached and returned to any concurrent second caller instead of
  racing.
- A new `RuntimeOperationGuard` is acquired before every
  engine-extracting / QNN-touching public API, so an in-progress
  shutdown can safely drain the registry without racing live
  operations. A thread-local reentrancy counter prevents self-deadlock
  if shutdown is triggered from within an already-guarded call on the
  same thread.
- `putQnnApp()` now returns `bool` and every call site
  checks/propagates failure instead of silently discarding a lost
  engine.
- A Python `atexit` hook is registered automatically (via a new pybind
  `InitializeRuntimeLifecycleStores()` / `ShutdownAllModels()`), so
  applications do not need to explicitly destroy every model before
  process exit. An explicit
  `qai_appbuilder.appbuilder._shutdown_all_models()` is also exposed
  for applications/tests that want a deterministic full teardown
  before exit; it is idempotent but permanently ends the native
  runtime for the process once completed.
- Fixed a pre-existing unconditional error log in the profile-handle
  teardown path and an uninitialized `StatusCode` local in
  `initializeProfileConfigOption()`. Hardened
  `tearDownInputAndOutputTensors()` / `freeGraphs()` against partially
  initialized engines, since `shutdown()` must also be safe as the
  destructor path for a failed `initialize()`.
- Documented "Model Lifecycle & Process-Exit Cleanup" (English +
  Chinese) in `docs/guide_en.md` / `docs/guide_zh.md`, including the
  new `_shutdown_all_models()` contract and how it differs from the
  existing Python-side `release_all()` helper.

## Testing

- Clean x64 and ARM64 (`aarch64-windows-msvc`) builds against QAIRT
  2.48.40.260702.
- Real-hardware HTP stress tests on Snapdragon X Elite covering:
  - Normal `del()`-triggered teardown.
  - Repeated create/inference/destroy cycles.
  - Concurrent multi-threaded init/inference/destroy.
  - Explicit `_shutdown_all_models()` idempotency.
  - Draining a never-explicitly-destroyed model left alive until
    process exit (the original crash scenario).
  - `atexit`-triggered cleanup.
  - The `profileFree` path with profiling enabled.

  All produced correct inference output with no crash.
