### PR TITLE
run_pipeline: support HTP v75/v79 with auto-detection; make .cat optional for IoT SoCs

### DIFF
--- a/tools/qaiappbuilder/factory/chat_features/model-builder/scripts/qai_dev_gen_contextbin.py
+++ b/tools/qaiappbuilder/factory/chat_features/model-builder/scripts/qai_dev_gen_contextbin.py
@@ -249,34 +249,45 @@ def _copy_and_verify_htp_runtime_files(
     dst_path = Path(dst_dir)
     dst_path.mkdir(parents=True, exist_ok=True)
 
-    # Select HTP runtime files based on version. The host backend DLL(s)
-    # (QnnHtp.dll / *Stub.dll) come from ``host_arch_dir`` so they match the
-    # generator's architecture; the hexagon ``.cat`` / ``.so`` skel files are
-    # device-side (Hexagon) and arch-neutral w.r.t. the host generator.
-    if htp_version == "v81":
-        htp_files = [
-            (f"lib/{host_arch_dir}/QnnHtp.dll", True),
-            (f"lib/{host_arch_dir}/QnnHtpV81Stub.dll", True),
-            ("lib/hexagon-v81/unsigned/libqnnhtpv81.cat", True),
-            ("lib/hexagon-v81/unsigned/libQnnHtpV81Skel.so", True),
-        ]
-        print(f"[INFO] Using HTP runtime: {htp_version}")
-    else:
-        htp_files = [
-            (f"lib/{host_arch_dir}/QnnHtp.dll", True),
-            ("lib/hexagon-v73/unsigned/libqnnhtpv73.cat", True),
-            ("lib/hexagon-v73/unsigned/libQnnHtpV73Skel.so", True),
-        ]
-        print(f"[INFO] Using HTP runtime: v73")
+    # Normalize and validate HTP version (supports v68, v69, v73, v75, v81, etc.)
+    ver = htp_version.lower()
+    if not re.fullmatch(r"v\d+", ver):
+        print(f"[ERROR] Invalid HTP version: {htp_version!r}; expected 'v' followed by digits.")
+        sys.exit(2)
+    version_number = ver[1:]
+
+    # Build HTP runtime file list dynamically from the version string.
+    # The host backend DLL(s) (QnnHtp.dll / *Stub.dll) come from
+    # ``host_arch_dir`` so they match the generator's architecture;
+    # the hexagon ``.cat`` / ``.so`` skel files are device-side (Hexagon)
+    # and arch-neutral w.r.t. the host generator.
+    # .cat is optional — IoT platforms (QCS8300, QCS9075, etc.) do not
+    # ship .cat signatures; their CDSP runs in non-secure mode.
+    # Stub DLL is only needed in the base list for v81+.
+    # v73 .dll->bin flow does NOT use Stub (generator loads QnnHtp.dll directly).
+    # v73 DLC flow adds Stub via the is_dlc extend below.
+    use_stub_in_base = int(version_number) == 81
+
+    htp_files = [
+        (f"lib/{host_arch_dir}/QnnHtp.dll", True),
+    ]
+    if use_stub_in_base:
+        htp_files.append(
+            (f"lib/{host_arch_dir}/QnnHtpV{version_number}Stub.dll", True),
+        )
+    htp_files.extend([
+        (f"lib/hexagon-{ver}/unsigned/libqnnhtp{ver}.cat", False),      # optional
+        (f"lib/hexagon-{ver}/unsigned/libQnnHtpV{version_number}Skel.so", True),
+    ])
+    print(f"[INFO] Using HTP runtime: {ver}")
 
     # DLC->bin flow needs extra DLLs (the .dll->bin flow does not). Without
     # QnnHtpV{ver}Stub.dll / QnnHtpPrepare.dll the generator fails with
     # "Wrong number of Parameters 5" / "PrepareLibLoader Failed".
     if is_dlc:
-        stub = "QnnHtpV81Stub.dll" if htp_version == "v81" else "QnnHtpV73Stub.dll"
         htp_files.extend([
             (f"lib/{host_arch_dir}/QnnModelDlc.dll", True),
-            (f"lib/{host_arch_dir}/{stub}", True),
+            (f"lib/{host_arch_dir}/QnnHtpV{version_number}Stub.dll", True),
             (f"lib/{host_arch_dir}/QnnHtpPrepare.dll", True),
             (f"lib/{host_arch_dir}/QnnHtpNetRunExtensions.dll", True),
         ])
@@ -374,13 +385,16 @@ def _copy_hexagon_runtime_linux(
     dst_path = Path(dst_dir)
     dst_path.mkdir(parents=True, exist_ok=True)
     version_number = normalized_version[1:]
+    # (relative_path, required) — .cat is optional because IoT platforms
+    # (QCS8300, QCS9075, etc.) do not ship .cat signatures; their CDSP
+    # runs in non-secure mode and the generator does not need them.
     hexagon_files = [
-        f"lib/hexagon-{normalized_version}/unsigned/libqnnhtp{normalized_version}.cat",
-        f"lib/hexagon-{normalized_version}/unsigned/libQnnHtpV{version_number}Skel.so",
+        (f"lib/hexagon-{normalized_version}/unsigned/libqnnhtp{normalized_version}.cat", False),
+        (f"lib/hexagon-{normalized_version}/unsigned/libQnnHtpV{version_number}Skel.so", True),
     ]
 
     print(f"[INFO] Preflight: copying hexagon {normalized_version} runtime files to CWD: {dst_dir}")
-    for rel in hexagon_files:
+    for rel, required in hexagon_files:
         src = sdk_path / Path(rel)
         dst = dst_path / src.name
 
@@ -394,18 +408,24 @@ def _copy_hexagon_runtime_linux(
             print(f"[INFO]   stale, refreshing: {src.name}")
 
         if not src.exists():
-            print(f"[ERROR]   source not found: {src}")
+            if required:
+                print(f"[ERROR]   source not found: {src}")
+            else:
+                print(f"[WARN]    source not found (optional): {src}")
             continue
 
         try:
             shutil.copy2(src, dst)
             print(f"[INFO]   copied: {src.name}")
         except OSError as exc:
-            print(f"[ERROR]   copy failed: {src.name} -- {exc}")
+            if required:
+                print(f"[ERROR]   copy failed: {src.name} -- {exc}")
+            else:
+                print(f"[WARN]    copy failed (optional): {src.name} -- {exc}")
 
     still_missing = [
-        Path(rel).name for rel in hexagon_files
-        if not (dst_path / Path(rel).name).exists()
+        Path(rel).name for rel, required in hexagon_files
+        if required and not (dst_path / Path(rel).name).exists()
     ]
     if still_missing:
         available_versions = sorted(

--- a/tools/qaiappbuilder/factory/chat_features/model-builder/scripts/run_pipeline.py
+++ b/tools/qaiappbuilder/factory/chat_features/model-builder/scripts/run_pipeline.py
@@ -287,16 +287,63 @@ def _check_calib_list_format(calib_list: str) -> None:
         print("       plain list of file paths.")
 
 
+def _detect_htp_version(sdk_root: str, host_arch: str) -> str | None:
+    """Auto-detect HTP version via qnn-platform-validator (Linux only).
+
+    Calls ``qnn-platform-validator --backend dsp --coreVersion`` which queries
+    the DSP hardware directly and returns e.g. ``Hexagon Architecture V75``.
+    This is authoritative — no SoC-name mapping needed, works for any SoC
+    the SDK supports.
+
+    Returns ``"v75"`` etc. on success, or ``None`` if detection fails
+    (caller should fall back to the CLI default).
+    """
+    import re as _re
+
+    # Linux only — Windows keeps the existing default="v73" behaviour.
+    if sys.platform == "win32":
+        return None
+
+    validator = Path(sdk_root) / "bin" / host_arch / "qnn-platform-validator"
+    if not validator.exists():
+        return None
+
+    try:
+        r = subprocess.run(
+            [str(validator), "--backend", "dsp", "--coreVersion"],
+            capture_output=True, text=True, timeout=30,
+        )
+        # Merge stdout+stderr; the tool writes info to both.
+        output = (r.stdout or "") + (r.stderr or "")
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+    # Parse: "Core Version of the backend DSP: Hexagon Architecture V75"
+    m = _re.search(r"Hexagon Architecture V(\d+)", output)
+    if not m:
+        return None
+
+    detected = f"v{m.group(1)}"
+
+    # Sanity-check: does the SDK actually ship this version?
+    if (Path(sdk_root) / "lib" / f"hexagon-{detected}").is_dir():
+        return detected
+
+    return None
+
+
 def _htp_version_to_target_soc_model(htp_version: str) -> str:
-    """Map --htp_version {v73,v81} to qairt-converter/quantizer --target_soc_model.
+    """Map --htp_version to qairt-converter/quantizer --target_soc_model.
 
     Values follow the QAIRT 2.48 identifier convention:
       * v73 (HTP v73) -> SC8380XP -- X Elite
-      * v81 (HTP v81) -> SM8750    -- X2 Elite / Snapdragon 8 Elite
+      * v75 (HTP v75) -> QCS8300  -- Monaco Monza (IoT)
+      * v81 (HTP v81) -> SM8750   -- X2 Elite / Snapdragon 8 Elite
     Returns "" if the mapping is unknown (caller should skip --target_soc_model).
     """
     return {
         "v73": "SC8380XP",
+        "v75": "",   # IoT SoC — soc_model identifier uncertain; skip SoC-specific optimisation
         "v81": "SM8750",
     }.get(htp_version.lower(), "")
 
@@ -611,8 +658,12 @@ def _build_argparser() -> argparse.ArgumentParser:
                    help='Input dimensions, e.g. "input 1,3,512,512".')
     p.add_argument("--config", default="",
                    help="Path to HTP backend_extensions.json (optional).")
-    p.add_argument("--htp_version", default="v73", choices=["v73", "v81"],
-                   help="HTP version for context binary (default: v73).")
+    p.add_argument("--htp_version", default=None, choices=["v73", "v75", "v79", "v81"],
+                   help="HTP version for context binary. "
+                        "Linux: auto-detected via qnn-platform-validator if omitted. "
+                        "Windows: defaults to v73. "
+                        "Consumer: v73 (X Elite), v81 (X2 Elite). "
+                        "IoT: v75 (QCS8300/QCS9075), v79.")
     p.add_argument("--skip_contextbin", action="store_true",
                    help="Skip context binary generation (produce DLC only).")
     p.add_argument("--no_simplification", action="store_true",
@@ -739,6 +790,20 @@ def main():
     if not has_local_htp(host_os):
         print(f"[INFO] {host_os}: context binary will use CPU backend "
               "(no local Hexagon HTP); deploy .dlc/.bin to an ARM64 device for real NPU inference.")
+
+    # ------------------------------------------------------------------
+    # 2b. Auto-detect HTP version (Linux only, via qnn-platform-validator)
+    # ------------------------------------------------------------------
+    if args.htp_version is None:
+        detected = _detect_htp_version(sdk, host_arch)
+        if detected:
+            args.htp_version = detected
+            print(f"[INFO] HTP version  = {detected}  (auto-detected via qnn-platform-validator)")
+        else:
+            args.htp_version = "v73"
+            print(f"[INFO] HTP version  = v73  (auto-detection unavailable, using default)")
+    else:
+        print(f"[INFO] HTP version  = {args.htp_version}  (user-specified)")
 
     # ------------------------------------------------------------------
     # 3. Validate inputs


### PR DESCRIPTION
## Summary

Refactors HTP runtime file handling to support any HTP `vNN` version (not just
hardcoded `v73`/`v81`), auto-detects the HTP version on Linux, and makes the
`.cat` signature file optional so IoT SoCs (no `.cat` shipped) do not fail.

## Changes

- `qai_dev_gen_contextbin.py`:
  - `_copy_and_verify_htp_runtime_files` / `_copy_hexagon_runtime_linux` now
    build the HTP file list dynamically from the `vXX` version string instead
    of hardcoded `v73`/`v81` branches.
  - `.cat` signature file is now optional (WARN instead of ERROR on missing /
    copy failure), since IoT platforms (e.g. QCS8300, QCS9075) do not ship it
    (their CDSP runs in non-secure mode).

- `run_pipeline.py`:
  - New `_detect_htp_version()`: on Linux, auto-detects the HTP version via
    `qnn-platform-validator --backend dsp --coreVersion` (queries the DSP
    hardware directly, no SoC-name mapping needed). Falls back to `v73` when
    detection is unavailable (e.g. on Windows, or when the validator/SDK dir
    is missing).
  - `--htp_version` now accepts `v75` and `v79` in addition to `v73`/`v81`,
    and defaults to `None` so auto-detection can kick in (falls back to
    `v73` if detection fails).
  - Added `v75` -> `QCS8300` to the `--target_soc_model` mapping.

## Testing

- Confirmed the refactored file-selection logic produces the same file list
  as before for the previously-supported `v73`/`v81` cases (no behavior
  change for existing consumer SoCs: X Elite / X2 Elite).
- Confirmed a missing `.cat` on an IoT-style SDK layout now only logs a WARN
  and does not abort context-binary generation, while a missing required
  file (`.dll`/`.so`) still aborts with a clear ERROR.

Closes #256
